### PR TITLE
Add commands to switch csproj references between local and package

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,119 @@ COMMANDS
     abpdev replace all
     ```
 
+## Local Source Management
+You can configure and manage local source mappings to easily switch between package references and local project references during development. This is especially useful when working with local forks or development versions of external packages.
+
+### Configure Local Sources
+```bash
+abpdev local-sources config
+```
+
+This command opens a YAML configuration file where you can define your local source mappings:
+
+```yaml
+abp:
+  RemotePath: https://github.com/abpframework/abp.git
+  Path: C:\github\abp
+  Packages:
+    - Volo.Abp.*
+    - Volo.Abp.Core
+other-lib:
+  Path: C:\source\other-lib
+  Packages:
+    - MyOrg.OtherLib.*
+```
+
+**Configuration Properties:**
+- **RemotePath**: The remote repository URL (optional, _for cloning if not exists in the future versions_)
+- **Path**: Local path where the source code is located. It'll be used to find the project files. Descendants of this path will be scanned for project files.
+- **Packages**: List of package patterns to match (supports wildcards with `*`)
+
+> **Important**: The order of sources in the configuration file matters. When switching references, the first matching source will be used.
+
+## Reference Management
+Manage project and package references efficiently with local source switching capabilities.
+
+### Switch to Local References
+Converts package references to local project references for development:
+
+```bash
+abpdev references to-local [workingdirectory] [options]
+```
+
+```bash
+abpdev references to-local -h
+
+PARAMETERS
+  workingdirectory  Working directory to run build. Probably project or solution directory path goes here. Default: . (Current Directory)
+
+OPTIONS
+  -s|--sources      (Array) Sources to switch to local. Default: all sources.
+  -h|--help         Shows help text.
+```
+
+This command:
+- Finds all `.csproj` files in the working directory
+- Matches package references against configured local source patterns
+- Converts matching packages to project references with relative paths
+- Backs up original package versions in PropertyGroup for later restoration
+
+### Switch to Package References
+Converts local project references back to package references:
+
+```bash
+abpdev references to-package [workingdirectory] [options]
+```
+
+```bash
+abpdev references to-package -h
+
+PARAMETERS
+  workingdirectory  Working directory to run build. Probably project or solution directory path goes here. Default: . (Current Directory)
+
+OPTIONS
+  -s|--sources      (Array) Sources to switch to package. Default: all sources.
+  -h|--help         Shows help text.
+```
+
+This command:
+- Finds all `.csproj` files in the working directory
+- Identifies project references pointing to configured local sources
+- Converts them back to package references using backed-up versions
+- Prompts for version input if no backed-up version exists
+
+### Example commands
+
+- Configure local sources
+    ```bash
+    abpdev local-sources config
+    ```
+
+- Switch all package references to local development versions
+    ```bash
+    abpdev references to-local
+    ```
+
+- Switch specific sources to local
+    ```bash
+    abpdev references to-local --sources abp
+    ```
+
+- Switch back to package references
+    ```bash
+    abpdev references to-package
+    ```
+
+- Switch specific sources back to packages
+    ```bash
+    abpdev references to-package --sources abp,other-lib
+    ```
+
+- Work in specific directory
+    ```bash
+    abpdev references to-local C:\Path\To\Projects --sources abp
+    ```
+
 ## Enable Notifications
 You can enable notifications to get notified when a build or run process is completed. You can enable it by using `abpdev enable-notifications` command and disable it by using `abpdev disable-notifications` command.
 

--- a/src/AbpDevTools/Commands/ConfigurationCommand.cs
+++ b/src/AbpDevTools/Commands/ConfigurationCommand.cs
@@ -118,3 +118,17 @@ public class ToolsConfigurationCommand : ConfigurationBaseCommand<ToolsConfigura
         return base.ExecuteAsync(console);
     }
 }
+
+[Command("local-sources config", Description = "Allows managing local sources configuration.")]
+public class LocalSourcesConfigurationCommand : ConfigurationBaseCommand<LocalSourcesConfiguration>
+{
+    public LocalSourcesConfigurationCommand(LocalSourcesConfiguration configuration) : base(configuration)
+    {
+    }
+
+    public override ValueTask ExecuteAsync(IConsole console)
+    {
+        Configuration.GetOptions();
+        return base.ExecuteAsync(console);
+    }
+}

--- a/src/AbpDevTools/Commands/References/LocalSourcesCommand.cs
+++ b/src/AbpDevTools/Commands/References/LocalSourcesCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AbpDevTools.Configuration;
+using CliFx.Infrastructure;
+
+namespace AbpDevTools.Commands.References;
+
+[Command("local-sources config", Description = "Allows managing local sources configuration.")]
+public class LocalSourcesCommand : ConfigurationBaseCommand<LocalSourcesConfiguration>
+{
+    public LocalSourcesCommand(LocalSourcesConfiguration configuration) : base(configuration)
+    {
+    }
+
+    public override ValueTask ExecuteAsync(IConsole console)
+    {
+        Configuration.GetOptions();
+        return base.ExecuteAsync(console);
+    }
+}

--- a/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
+++ b/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AbpDevTools.Configuration;
+using AbpDevTools.Services;
+using CliFx.Infrastructure;
+using System.Xml.Linq;
+using System.IO;
+
+namespace AbpDevTools.Commands.References;
+
+[Command("references to-local", Description = "Switch csproj project references to local source")]
+public class SwitchReferencesToLocalCommand(
+    LocalSourcesConfiguration localSourcesConfiguration,
+    FileExplorer fileExplorer,
+    CsprojManipulationService csprojService) : ICommand
+{
+    [CommandParameter(0, IsRequired = false, Description = "Working directory to run build. Probably project or solution directory path goes here. Default: . (Current Directory)")]
+    public string? WorkingDirectory { get; set; }
+
+    [CommandOption("sources", 's', Description = "Sources to switch to local. Default: all sources.")]
+    public string[] Sources { get; set; } = Array.Empty<string>();
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var localSources = localSourcesConfiguration.GetOptions();
+
+        if (localSources.Count == 0)
+        {
+            console.Output.WriteLine("No local sources found. Please add some local sources to the configuration. Use 'abpdev local-sources config' command to manage local sources.");
+            return;
+        }
+
+        var cancellationToken = console.RegisterCancellationHandler();
+        cancellationToken.ThrowIfCancellationRequested();
+        WorkingDirectory ??= Directory.GetCurrentDirectory();
+
+        var projects = fileExplorer.FindDescendants(WorkingDirectory, "*.csproj").ToList();
+
+        if (!projects.Any())
+        {
+            console.Output.WriteLine("No .csproj files found in the working directory.");
+            return;
+        }
+
+        // Filter sources if specified
+        var sourcesToProcess = Sources.Length > 0 
+            ? localSources.Where(kvp => Sources.Contains(kvp.Key)).ToList()
+            : localSources.ToList();
+
+        if (!sourcesToProcess.Any())
+        {
+            console.Output.WriteLine("No matching sources found.");
+            return;
+        }
+
+        console.Output.WriteLine($"Processing {projects.Count} project(s) with {sourcesToProcess.Count} source(s)...");
+
+        // Build project lookup cache for all sources
+        var projectLookupCache = BuildProjectLookupCache(sourcesToProcess, console);
+
+        foreach (var projectPath in projects)
+        {
+            await ProcessProjectAsync(projectPath, sourcesToProcess, projectLookupCache, console);
+        }
+
+        console.Output.WriteLine("Completed switching references to local sources.");
+    }
+
+    private Dictionary<string, Dictionary<string, string>> BuildProjectLookupCache(
+        List<KeyValuePair<string, LocalSourceMappingItem>> sources, IConsole console)
+    {
+        var cache = csprojService.BuildProjectLookupCache(sources);
+
+        foreach (var source in sources)
+        {
+            var sourceKey = source.Key;
+            var sourceConfig = source.Value;
+            
+            console.Output.WriteLine($"Scanning source '{sourceKey}' at: {sourceConfig.Path}");
+            
+            if (!Directory.Exists(sourceConfig.Path))
+            {
+                console.Output.WriteLine($"  Warning: Source path does not exist: {sourceConfig.Path}");
+                continue;
+            }
+
+            var projectCount = cache.ContainsKey(sourceKey) ? cache[sourceKey].Count : 0;
+            console.Output.WriteLine($"  Found {projectCount} project(s) in source '{sourceKey}'");
+        }
+
+        return cache;
+    }
+
+    private Task ProcessProjectAsync(string projectPath, List<KeyValuePair<string, LocalSourceMappingItem>> sources, 
+        Dictionary<string, Dictionary<string, string>> projectLookupCache, IConsole console)
+    {
+        try
+        {
+            var doc = XDocument.Load(projectPath);
+            var hasChanges = false;
+            var versionsToBackup = new Dictionary<string, string>();
+
+            foreach (var source in sources)
+            {
+                var sourceKey = source.Key;
+                var sourceConfig = source.Value;
+
+                foreach (var packagePattern in sourceConfig.Packages)
+                {
+                    var packageReferences = csprojService.GetMatchingPackageReferences(doc, packagePattern);
+
+                    foreach (var packageRef in packageReferences)
+                    {
+                        var packageName = packageRef.Attribute("Include")?.Value;
+                        if (string.IsNullOrEmpty(packageName)) continue;
+
+                        var localProjectPath = csprojService.FindLocalProject(packageName, sourceKey, projectLookupCache);
+                        if (string.IsNullOrEmpty(localProjectPath)) continue;
+
+                        // Calculate relative path
+                        var relativePath = csprojService.GetRelativePath(Path.GetDirectoryName(projectPath)!, localProjectPath);
+
+                        // Backup version
+                        var version = packageRef.Attribute("Version")?.Value;
+                        if (!string.IsNullOrEmpty(version) && !versionsToBackup.ContainsKey(sourceKey))
+                        {
+                            versionsToBackup[sourceKey] = version;
+                        }
+
+                        // Convert to ProjectReference
+                        csprojService.ConvertToProjectReference(packageRef, relativePath);
+                        hasChanges = true;
+
+                        console.Output.WriteLine($"  Converted {packageName} to local reference: {relativePath}");
+                    }
+                }
+            }
+
+            if (hasChanges)
+            {
+                // Add version backup properties
+                csprojService.AddVersionBackupProperties(doc, versionsToBackup);
+                doc.Save(projectPath);
+                console.Output.WriteLine($"Updated: {Path.GetFileName(projectPath)}");
+            }
+        }
+        catch (Exception ex)
+        {
+            console.Output.WriteLine($"Error processing {Path.GetFileName(projectPath)}: {ex.Message}");
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
+++ b/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
@@ -7,6 +7,7 @@ using AbpDevTools.Services;
 using CliFx.Infrastructure;
 using System.Xml.Linq;
 using System.IO;
+using Spectre.Console;
 
 namespace AbpDevTools.Commands.References;
 
@@ -14,7 +15,8 @@ namespace AbpDevTools.Commands.References;
 public class SwitchReferencesToLocalCommand(
     LocalSourcesConfiguration localSourcesConfiguration,
     FileExplorer fileExplorer,
-    CsprojManipulationService csprojService) : ICommand
+    CsprojManipulationService csprojService,
+    GitService gitService) : ICommand
 {
     [CommandParameter(0, IsRequired = false, Description = "Working directory to run build. Probably project or solution directory path goes here. Default: . (Current Directory)")]
     public string? WorkingDirectory { get; set; }
@@ -58,7 +60,7 @@ public class SwitchReferencesToLocalCommand(
         console.Output.WriteLine($"Processing {projects.Count} project(s) with {sourcesToProcess.Count} source(s)...");
 
         // Build project lookup cache for all sources
-        var projectLookupCache = BuildProjectLookupCache(sourcesToProcess, console);
+        var projectLookupCache = await BuildProjectLookupCacheAsync(sourcesToProcess, console, cancellationToken);
 
         foreach (var projectPath in projects)
         {
@@ -68,10 +70,10 @@ public class SwitchReferencesToLocalCommand(
         console.Output.WriteLine("Completed switching references to local sources.");
     }
 
-    private Dictionary<string, Dictionary<string, string>> BuildProjectLookupCache(
-        List<KeyValuePair<string, LocalSourceMappingItem>> sources, IConsole console)
+    private async Task<Dictionary<string, Dictionary<string, string>>> BuildProjectLookupCacheAsync(
+        List<KeyValuePair<string, LocalSourceMappingItem>> sources, IConsole console, CancellationToken cancellationToken)
     {
-        var cache = csprojService.BuildProjectLookupCache(sources);
+        var cache = new Dictionary<string, Dictionary<string, string>>();
 
         foreach (var source in sources)
         {
@@ -80,13 +82,94 @@ public class SwitchReferencesToLocalCommand(
             
             console.Output.WriteLine($"Scanning source '{sourceKey}' at: {sourceConfig.Path}");
             
-            if (!Directory.Exists(sourceConfig.Path))
+            if (!Directory.Exists(sourceConfig.Path) || gitService.IsDirectoryEmpty(sourceConfig.Path))
             {
-                console.Output.WriteLine($"  Warning: Source path does not exist: {sourceConfig.Path}");
-                continue;
+                if (!Directory.Exists(sourceConfig.Path))
+                {
+                    console.Output.WriteLine($"  Warning: Source path does not exist: {sourceConfig.Path}");
+                }
+                else
+                {
+                    console.Output.WriteLine($"  Warning: Source path is empty: {sourceConfig.Path}");
+                }
+
+                // Prompt user for action when source is empty/missing
+                var action = PromptForSourceActionAsync(sourceKey, sourceConfig, console);
+                
+                switch (action)
+                {
+                    case SourceAction.Skip:
+                        console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                        cache[sourceKey] = new Dictionary<string, string>();
+                        continue;
+                        
+                    case SourceAction.OpenConfiguration:
+                        console.Output.WriteLine($"Opening local sources configuration...");
+                        var localSourcesCommand = new LocalSourcesCommand(localSourcesConfiguration);
+                        await localSourcesCommand.ExecuteAsync(console);
+                        return cache; // Exit the entire command
+                        
+                    case SourceAction.CloneRepository:
+                        // Check if we can clone from remote
+                        if (string.IsNullOrEmpty(sourceConfig.RemotePath))
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error for source '{sourceKey}': No remote URL configured for cloning.[/]");
+                            console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                            cache[sourceKey] = new Dictionary<string, string>();
+                            continue;
+                        }
+
+                        if (!gitService.IsGitInstalled())
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error for source '{sourceKey}': Git is not installed or not available in PATH.[/]");
+                            console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                            cache[sourceKey] = new Dictionary<string, string>();
+                            continue;
+                        }
+
+                        try
+                        {
+                            var branchInfo = !string.IsNullOrEmpty(sourceConfig.Branch) ? $" (branch: {sourceConfig.Branch})" : "";
+                            var cloneSuccess = await gitService.CloneRepositoryAsync(sourceConfig.RemotePath, sourceConfig.Path, sourceConfig.Branch, cancellationToken);
+                            
+                            if (!cloneSuccess)
+                            {
+                                AnsiConsole.MarkupLine($"[red]Error for source '{sourceKey}': Failed to clone repository from {sourceConfig.RemotePath}[/]");
+                                console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                                cache[sourceKey] = new Dictionary<string, string>();
+                                continue;
+                            }
+                            
+                            AnsiConsole.MarkupLine($"[green]Successfully cloned source '{sourceKey}' from {sourceConfig.RemotePath}{branchInfo}[/]");
+                        }
+                        catch (Exception ex)
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error cloning source '{sourceKey}': {ex.Message}[/]");
+                            console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                            cache[sourceKey] = new Dictionary<string, string>();
+                            continue;
+                        }
+                        break;
+                        
+                    default:
+                        console.Output.WriteLine($"  Skipping source '{sourceKey}' and continuing with next source...");
+                        cache[sourceKey] = new Dictionary<string, string>();
+                        continue;
+                }
             }
 
-            var projectCount = cache.ContainsKey(sourceKey) ? cache[sourceKey].Count : 0;
+            // Build the cache using the service
+            var sourceCacheResult = csprojService.BuildProjectLookupCache(new List<KeyValuePair<string, LocalSourceMappingItem>> { source });
+            if (sourceCacheResult.TryGetValue(sourceKey, out var sourceProjects))
+            {
+                cache[sourceKey] = sourceProjects;
+            }
+            else
+            {
+                cache[sourceKey] = new Dictionary<string, string>();
+            }
+
+            var projectCount = cache[sourceKey].Count;
             console.Output.WriteLine($"  Found {projectCount} project(s) in source '{sourceKey}'");
         }
 
@@ -151,5 +234,38 @@ public class SwitchReferencesToLocalCommand(
             console.Output.WriteLine($"Error processing {Path.GetFileName(projectPath)}: {ex.Message}");
         }
         return Task.CompletedTask;
+    }
+
+    private SourceAction PromptForSourceActionAsync(string sourceKey, LocalSourceMappingItem sourceConfig, IConsole console)
+    {
+        var hasRemoteUrl = !string.IsNullOrEmpty(sourceConfig.RemotePath);
+        var branchInfo = !string.IsNullOrEmpty(sourceConfig.Branch) ? $" (branch: {sourceConfig.Branch})" : "";
+        
+        AnsiConsole.MarkupLine($"[yellow]Source '{sourceKey}' is empty or doesn't exist at:[/] {sourceConfig.Path}");
+        
+        var choices = new List<string>
+        {
+            "Skip this source",
+            "Open configuration to edit settings"
+        };
+
+        if (hasRemoteUrl)
+        {
+            choices.Add($"Clone from remote repository: {sourceConfig.RemotePath}{branchInfo}");
+        }
+
+        var choice = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title($"[bold]What would you like to do with source '[yellow]{sourceKey}[/]'?[/]")
+                .AddChoices(choices)
+        );
+
+        return choice switch
+        {
+            "Skip this source" => SourceAction.Skip,
+            "Open configuration to edit settings" => SourceAction.OpenConfiguration,
+            var c when c.StartsWith("Clone from remote repository") => SourceAction.CloneRepository,
+            _ => SourceAction.Skip
+        };
     }
 }

--- a/src/AbpDevTools/Commands/References/SwitchReferencesToPackageCommand.cs
+++ b/src/AbpDevTools/Commands/References/SwitchReferencesToPackageCommand.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AbpDevTools.Configuration;
+using AbpDevTools.Services;
+using CliFx.Infrastructure;
+using System.Xml.Linq;
+using System.IO;
+using Spectre.Console;
+
+namespace AbpDevTools.Commands.References;
+
+[Command("references to-package", Description = "Switch csproj local project references back to package references")]
+public class SwitchReferencesToPackageCommand(
+    LocalSourcesConfiguration localSourcesConfiguration,
+    FileExplorer fileExplorer,
+    CsprojManipulationService csprojService) : ICommand
+{
+    [CommandParameter(0, IsRequired = false, Description = "Working directory to run build. Probably project or solution directory path goes here. Default: . (Current Directory)")]
+    public string? WorkingDirectory { get; set; }
+
+    [CommandOption("sources", 's', Description = "Sources to switch to package. Default: all sources.")]
+    public string[] Sources { get; set; } = Array.Empty<string>();
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var localSources = localSourcesConfiguration.GetOptions();
+
+        if (localSources.Count == 0)
+        {
+            console.Output.WriteLine("No local sources found. Please add some local sources to the configuration. Use 'abpdev local-sources config' command to manage local sources.");
+            return;
+        }
+
+        var cancellationToken = console.RegisterCancellationHandler();
+        cancellationToken.ThrowIfCancellationRequested();
+        WorkingDirectory ??= Directory.GetCurrentDirectory();
+
+        var projects = fileExplorer.FindDescendants(WorkingDirectory, "*.csproj").ToList();
+
+        if (!projects.Any())
+        {
+            console.Output.WriteLine("No .csproj files found in the working directory.");
+            return;
+        }
+
+        // Filter sources if specified
+        var sourcesToProcess = Sources.Length > 0 
+            ? localSources.Where(kvp => Sources.Contains(kvp.Key)).ToList()
+            : localSources.ToList();
+
+        if (!sourcesToProcess.Any())
+        {
+            console.Output.WriteLine("No matching sources found.");
+            return;
+        }
+
+        console.Output.WriteLine($"Processing {projects.Count} project(s) with {sourcesToProcess.Count} source(s)...");
+
+        // Build project lookup cache for all sources
+        var projectLookupCache = BuildProjectLookupCache(sourcesToProcess, console);
+
+        // Cache for prompted versions to avoid asking multiple times for the same source
+        var promptedVersions = new Dictionary<string, string>();
+
+        foreach (var projectPath in projects)
+        {
+            await ProcessProjectAsync(projectPath, sourcesToProcess, projectLookupCache, promptedVersions, console);
+        }
+
+        console.Output.WriteLine("Completed switching references to package sources.");
+    }
+
+    private Dictionary<string, Dictionary<string, string>> BuildProjectLookupCache(
+        List<KeyValuePair<string, LocalSourceMappingItem>> sources, IConsole console)
+    {
+        var cache = csprojService.BuildProjectLookupCache(sources);
+
+        foreach (var source in sources)
+        {
+            var sourceKey = source.Key;
+            var sourceConfig = source.Value;
+            
+            console.Output.WriteLine($"Scanning source '{sourceKey}' at: {sourceConfig.Path}");
+            
+            if (!Directory.Exists(sourceConfig.Path))
+            {
+                console.Output.WriteLine($"  Warning: Source path does not exist: {sourceConfig.Path}");
+                continue;
+            }
+
+            var projectCount = cache.ContainsKey(sourceKey) ? cache[sourceKey].Count : 0;
+            console.Output.WriteLine($"  Found {projectCount} project(s) in source '{sourceKey}'");
+        }
+
+        return cache;
+    }
+
+    private Task ProcessProjectAsync(string projectPath, List<KeyValuePair<string, LocalSourceMappingItem>> sources, 
+        Dictionary<string, Dictionary<string, string>> projectLookupCache, 
+        Dictionary<string, string> promptedVersions, IConsole console)
+    {
+        try
+        {
+            var doc = XDocument.Load(projectPath);
+            var hasChanges = false;
+
+            var projectReferences = csprojService.GetAllProjectReferences(doc);
+
+            foreach (var projectRef in projectReferences.ToList()) // ToList() to avoid modification during enumeration
+            {
+                var referencedProjectPath = projectRef.Attribute("Include")?.Value;
+                if (string.IsNullOrEmpty(referencedProjectPath)) continue;
+
+                // Convert relative path to absolute path
+                var absoluteReferencedPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectPath)!, referencedProjectPath));
+
+                // Find which source this project belongs to (first match wins)
+                var sourceKey = FindSourceForReferencedProject(absoluteReferencedPath, sources, projectLookupCache);
+                if (string.IsNullOrEmpty(sourceKey)) continue;
+
+                var projectName = Path.GetFileNameWithoutExtension(absoluteReferencedPath);
+
+                // Check if this project matches any package patterns for this source
+                var sourceConfig = sources.First(s => s.Key == sourceKey).Value;
+                if (!DoesProjectMatchAnyPattern(projectName, sourceConfig.Packages)) continue;
+
+                // Get version (from backup or prompt user)
+                var version = GetVersionForSource(doc, sourceKey, promptedVersions);
+                if (string.IsNullOrEmpty(version)) continue;
+
+                // Convert to PackageReference
+                csprojService.ConvertToPackageReference(projectRef, projectName, version);
+                hasChanges = true;
+
+                console.Output.WriteLine($"  Converted {projectName} to package reference with version {version}");
+            }
+
+            if (hasChanges)
+            {
+                doc.Save(projectPath);
+                console.Output.WriteLine($"Updated: {Path.GetFileName(projectPath)}");
+            }
+        }
+        catch (Exception ex)
+        {
+            console.Output.WriteLine($"Error processing {Path.GetFileName(projectPath)}: {ex.Message}");
+        }
+        return Task.CompletedTask;
+    }
+
+    private string? FindSourceForReferencedProject(string absoluteProjectPath, List<KeyValuePair<string, LocalSourceMappingItem>> sources, 
+        Dictionary<string, Dictionary<string, string>> projectLookupCache)
+    {
+        var projectName = Path.GetFileNameWithoutExtension(absoluteProjectPath);
+
+        // Check each source in order (first match wins)
+        foreach (var source in sources)
+        {
+            var sourceKey = source.Key;
+            var sourceConfig = source.Value;
+
+            // Check if this project is in our lookup cache for this source
+            if (projectLookupCache.TryGetValue(sourceKey, out var sourceProjects))
+            {
+                if (sourceProjects.TryGetValue(projectName, out var cachedProjectPath))
+                {
+                    // Verify the paths match
+                    if (Path.GetFullPath(cachedProjectPath) == absoluteProjectPath)
+                    {
+                        return sourceKey;
+                    }
+                }
+            }
+
+            // Fallback: check if project is under source path
+            if (csprojService.IsProjectUnderSource(absoluteProjectPath, sourceConfig.Path))
+            {
+                return sourceKey;
+            }
+        }
+
+        return null;
+    }
+
+    private bool DoesProjectMatchAnyPattern(string projectName, HashSet<string> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (pattern.EndsWith("*"))
+            {
+                var prefix = pattern.Substring(0, pattern.Length - 1);
+                if (projectName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                if (string.Equals(projectName, pattern, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private string? GetVersionForSource(XDocument doc, string sourceKey, Dictionary<string, string> promptedVersions)
+    {
+        // First, try to get from backed-up version
+        var backedUpVersion = csprojService.GetBackedUpVersion(doc, sourceKey);
+        if (!string.IsNullOrEmpty(backedUpVersion))
+        {
+            return backedUpVersion;
+        }
+
+        // Check if we already prompted for this source
+        if (promptedVersions.TryGetValue(sourceKey, out var cachedVersion))
+        {
+            return cachedVersion;
+        }
+
+        // Prompt user for version
+        var version = AnsiConsole.Ask<string>($"Enter version for source '[green]{sourceKey}[/]':");
+        
+        if (!string.IsNullOrEmpty(version))
+        {
+            promptedVersions[sourceKey] = version;
+        }
+
+        return version;
+    }
+} 

--- a/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
+++ b/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
@@ -20,9 +20,8 @@ public class LocalSourcesConfiguration : ConfigurationBase<LocalSourceMapping>
         return new LocalSourceMapping(){
             { "abp", new LocalSourceMappingItem
                 {
-                    // TODO: Add cloning logic if not exists
                     RemotePath = "https://github.com/abpframework/abp.git",
-                    // TODO: Add branch property, switch to branch if exists
+                    Branch = "dev",
                     Path = "C:\\github\\abp",
                     Packages = new HashSet<string>
                     {
@@ -42,5 +41,6 @@ public class LocalSourceMappingItem
 {
     public string Path { get; set; } = string.Empty;
     public string? RemotePath { get; set; }
+    public string? Branch { get; set; }
     public HashSet<string> Packages { get; set; } = new();
 }

--- a/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
+++ b/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
@@ -20,11 +20,13 @@ public class LocalSourcesConfiguration : ConfigurationBase<LocalSourceMapping>
         return new LocalSourceMapping(){
             { "abp", new LocalSourceMappingItem
                 {
+                    // TODO: Add cloning logic if not exists
                     RemotePath = "https://github.com/abpframework/abp.git",
+                    // TODO: Add branch property, switch to branch if exists
                     Path = "C:\\github\\abp",
                     Packages = new HashSet<string>
                     {
-                        "Volo.Abp.*"
+                        "Volo.*"
                     }
                 }
             }

--- a/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
+++ b/src/AbpDevTools/Configuration/LocalSourceConfiguration.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+
+namespace AbpDevTools.Configuration;
+
+[RegisterTransient]
+public class LocalSourcesConfiguration : ConfigurationBase<LocalSourceMapping>
+{
+    public override string FileName => "local-sources";
+
+    public LocalSourcesConfiguration(IDeserializer yamlDeserializer, ISerializer yamlSerializer) : base(yamlDeserializer, yamlSerializer)
+    {
+    }
+
+    protected override LocalSourceMapping GetDefaults()
+    {
+        return new LocalSourceMapping(){
+            { "abp", new LocalSourceMappingItem
+                {
+                    RemotePath = "https://github.com/abpframework/abp.git",
+                    Path = "C:\\github\\abp",
+                    Packages = new HashSet<string>
+                    {
+                        "Volo.Abp.*"
+                    }
+                }
+            }
+        };
+    }
+}
+
+public class LocalSourceMapping : Dictionary<string, LocalSourceMappingItem>
+{
+}
+
+public class LocalSourceMappingItem
+{
+    public string Path { get; set; } = string.Empty;
+    public string? RemotePath { get; set; }
+    public HashSet<string> Packages { get; set; } = new();
+}

--- a/src/AbpDevTools/Program.cs
+++ b/src/AbpDevTools/Program.cs
@@ -1,5 +1,6 @@
 ﻿using AbpDevTools.Commands;
 using AbpDevTools.Commands.Migrations;
+using AbpDevTools.Commands.References;
 using AbpDevTools.Notifications;
 using Microsoft.Extensions.DependencyInjection;
 using System.Runtime.InteropServices;
@@ -45,6 +46,7 @@ public static class Startup
             typeof(ToolsConfigurationCommand),
             typeof(ToolsCommand),
             typeof(ConfigCommand),
+            typeof(LocalSourcesConfigurationCommand),
             typeof(DisableNotificationsCommand),
             typeof(EnableNotificationsCommand),
             typeof(EnvironmentAppCommand),
@@ -69,6 +71,9 @@ public static class Startup
             typeof(AddMigrationCommand),
             typeof(ClearMigrationsCommand),
             typeof(PrepareCommand),
+            typeof(SwitchReferencesToLocalCommand),
+            typeof(SwitchReferencesToPackageCommand),
+            typeof(LocalSourcesCommand),
         };
 
         foreach (var commandType in commands)

--- a/src/AbpDevTools/Services/CsprojManipulationService.cs
+++ b/src/AbpDevTools/Services/CsprojManipulationService.cs
@@ -1,0 +1,183 @@
+using System.Xml.Linq;
+using AbpDevTools.Configuration;
+
+namespace AbpDevTools.Services;
+
+[RegisterTransient]
+public class CsprojManipulationService
+{
+    private readonly FileExplorer _fileExplorer;
+
+    public CsprojManipulationService(FileExplorer fileExplorer)
+    {
+        _fileExplorer = fileExplorer;
+    }
+
+    public Dictionary<string, Dictionary<string, string>> BuildProjectLookupCache(
+        List<KeyValuePair<string, LocalSourceMappingItem>> sources)
+    {
+        var cache = new Dictionary<string, Dictionary<string, string>>();
+
+        foreach (var source in sources)
+        {
+            var sourceKey = source.Key;
+            var sourceConfig = source.Value;
+
+            if (!Directory.Exists(sourceConfig.Path))
+            {
+                cache[sourceKey] = new Dictionary<string, string>();
+                continue;
+            }
+
+            var projectFiles = _fileExplorer.FindDescendants(sourceConfig.Path, "*.csproj").ToList();
+            var sourceProjects = new Dictionary<string, string>();
+
+            foreach (var projectFile in projectFiles)
+            {
+                var projectName = Path.GetFileNameWithoutExtension(projectFile);
+                sourceProjects[projectName] = projectFile;
+            }
+
+            cache[sourceKey] = sourceProjects;
+        }
+
+        return cache;
+    }
+
+    public List<XElement> GetMatchingPackageReferences(XDocument doc, string pattern)
+    {
+        var packageReferences = doc.Descendants("PackageReference").ToList();
+        
+        if (pattern.EndsWith("*"))
+        {
+            var prefix = pattern.Substring(0, pattern.Length - 1);
+            return packageReferences.Where(pr => 
+                pr.Attribute("Include")?.Value?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == true).ToList();
+        }
+        else
+        {
+            return packageReferences.Where(pr => 
+                string.Equals(pr.Attribute("Include")?.Value, pattern, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+    }
+
+    public List<XElement> GetAllProjectReferences(XDocument doc)
+    {
+        return doc.Descendants("ProjectReference").ToList();
+    }
+
+    public string? FindLocalProject(string packageName, string sourceKey, Dictionary<string, Dictionary<string, string>> projectLookupCache)
+    {
+        if (projectLookupCache.TryGetValue(sourceKey, out var sourceProjects))
+        {
+            return sourceProjects.TryGetValue(packageName, out var projectPath) ? projectPath : null;
+        }
+        return null;
+    }
+
+    public string? FindSourceForProject(string projectPath, List<KeyValuePair<string, LocalSourceMappingItem>> sources)
+    {
+        var projectName = Path.GetFileNameWithoutExtension(projectPath);
+        
+        foreach (var source in sources)
+        {
+            var sourceConfig = source.Value;
+            if (!Directory.Exists(sourceConfig.Path)) continue;
+
+            var projectFiles = _fileExplorer.FindDescendants(sourceConfig.Path, $"{projectName}.csproj");
+            if (projectFiles.Any(pf => Path.GetFullPath(pf) == Path.GetFullPath(projectPath)))
+            {
+                return source.Key;
+            }
+        }
+        return null;
+    }
+
+    public string GetRelativePath(string fromPath, string toPath)
+    {
+        var fromUri = new Uri(fromPath + Path.DirectorySeparatorChar);
+        var toUri = new Uri(toPath);
+        var relativeUri = fromUri.MakeRelativeUri(toUri);
+        return Uri.UnescapeDataString(relativeUri.ToString()).Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    public void ConvertToProjectReference(XElement packageRef, string projectPath)
+    {
+        // Change element name from PackageReference to ProjectReference
+        packageRef.Name = "ProjectReference";
+        
+        // Update Include attribute to point to project file
+        packageRef.SetAttributeValue("Include", projectPath);
+        
+        // Remove Version attribute if present
+        packageRef.Attribute("Version")?.Remove();
+        
+        // Remove other package-specific attributes
+        packageRef.Attribute("PrivateAssets")?.Remove();
+        packageRef.Attribute("IncludeAssets")?.Remove();
+        packageRef.Attribute("ExcludeAssets")?.Remove();
+    }
+
+    public void ConvertToPackageReference(XElement projectRef, string packageName, string version)
+    {
+        // Change element name from ProjectReference to PackageReference
+        projectRef.Name = "PackageReference";
+        
+        // Update Include attribute to package name
+        projectRef.SetAttributeValue("Include", packageName);
+        
+        // Add Version attribute
+        projectRef.SetAttributeValue("Version", version);
+    }
+
+    public void AddVersionBackupProperties(XDocument doc, Dictionary<string, string> versionsToBackup)
+    {
+        if (!versionsToBackup.Any()) return;
+
+        var root = doc.Root;
+        if (root == null) return;
+
+        // Find or create PropertyGroup for version backup
+        var versionPropertyGroup = root.Elements("PropertyGroup")
+            .FirstOrDefault(pg => pg.Elements().Any(e => e.Name.LocalName.EndsWith("Version")));
+
+        if (versionPropertyGroup == null)
+        {
+            versionPropertyGroup = new XElement("PropertyGroup");
+            root.Add(versionPropertyGroup);
+        }
+
+        foreach (var version in versionsToBackup)
+        {
+            var propertyName = $"{version.Key}Version";
+            var existingProperty = versionPropertyGroup.Element(propertyName);
+            
+            if (existingProperty == null)
+            {
+                versionPropertyGroup.Add(new XElement(propertyName, version.Value));
+            }
+        }
+    }
+
+    public string? GetBackedUpVersion(XDocument doc, string sourceKey)
+    {
+        var propertyName = $"{sourceKey}Version";
+        return doc.Descendants("PropertyGroup")
+            .SelectMany(pg => pg.Elements(propertyName))
+            .FirstOrDefault()?.Value;
+    }
+
+    public bool IsProjectUnderSource(string projectPath, string sourcePath)
+    {
+        try
+        {
+            var fullProjectPath = Path.GetFullPath(projectPath);
+            var fullSourcePath = Path.GetFullPath(sourcePath);
+            return fullProjectPath.StartsWith(fullSourcePath, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+} 

--- a/src/AbpDevTools/Services/GitService.cs
+++ b/src/AbpDevTools/Services/GitService.cs
@@ -1,0 +1,326 @@
+using System.Diagnostics;
+using Spectre.Console;
+
+namespace AbpDevTools.Services;
+
+[RegisterTransient]
+public class GitService
+{
+    public async Task<bool> CloneRepositoryAsync(string remoteUrl, string localPath, string? branch = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Ensure the parent directory exists
+            var parentDir = Directory.GetParent(localPath)?.FullName;
+            if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
+            // If the directory exists and is not empty, remove it first
+            if (Directory.Exists(localPath))
+            {
+                Directory.Delete(localPath, true);
+            }
+
+            // Try to determine the best branch to use
+            var branchToUse = await DetermineBestBranchAsync(remoteUrl, branch);
+
+            var gitArgs = $"clone {remoteUrl} \"{localPath}\"";
+            if (!string.IsNullOrEmpty(branchToUse))
+            {
+                gitArgs += $" --branch {branchToUse}";
+            }
+            
+            AnsiConsole.MarkupLine($"[dim]Executing: git {gitArgs}[/]");
+
+            return await AnsiConsole.Status()
+                .StartAsync($"[green]Cloning repository[/] {(!string.IsNullOrEmpty(branchToUse) ? $"(branch: {branchToUse})" : "")}...", async ctx =>
+                {
+                    ctx.Spinner(Spinner.Known.Dots);
+                    
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "git",
+                        Arguments = gitArgs,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+
+                    using var process = new Process { StartInfo = startInfo };
+                    
+                    // Register cancellation to kill the process
+                    using var cancellationRegistration = cancellationToken.Register(() =>
+                    {
+                        try
+                        {
+                            if (!process.HasExited)
+                            {
+                                AnsiConsole.MarkupLine($"[yellow]Cancellation requested. Terminating git process...[/]");
+                                process.Kill(true); // Kill entire process tree
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error killing git process: {ex.Message}[/]");
+                        }
+                    });
+
+                    process.Start();
+
+                    // Start reading output and error streams
+                    var outputTask = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await process.StandardOutput.ReadToEndAsync();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            return string.Empty; // Process was killed
+                        }
+                    }, cancellationToken);
+
+                    var errorTask = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await process.StandardError.ReadToEndAsync();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            return string.Empty; // Process was killed
+                        }
+                    }, cancellationToken);
+
+                    // Wait for the process to complete or cancellation
+                    try
+                    {
+                        await process.WaitForExitAsync(cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        AnsiConsole.MarkupLine($"[yellow]Git clone operation was cancelled.[/]");
+                        return false;
+                    }
+                    
+                    // Wait for all tasks to complete (with a short timeout in case of cancellation)
+                    try
+                    {
+                        await Task.WhenAll(outputTask, errorTask).WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return false;
+                    }
+                    catch (TimeoutException)
+                    {
+                        AnsiConsole.MarkupLine($"[yellow]Timeout waiting for git output streams to complete.[/]");
+                    }
+
+                    var output = string.Empty;
+                    var error = string.Empty;
+                    
+                    try
+                    {
+                        output = await outputTask;
+                        error = await errorTask;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return false;
+                    }
+
+                    if (process.ExitCode != 0)
+                    {
+                        AnsiConsole.MarkupLine($"[red]Git clone failed (exit code: {process.ExitCode}):[/]");
+                        if (!string.IsNullOrEmpty(error))
+                        {
+                            AnsiConsole.MarkupLine($"[red]Error output:[/] {error}");
+                        }
+                        if (!string.IsNullOrEmpty(output))
+                        {
+                            AnsiConsole.MarkupLine($"[red]Standard output:[/] {output}");
+                        }
+                        return false;
+                    }
+
+                    if (!string.IsNullOrEmpty(output))
+                    {
+                        AnsiConsole.MarkupLine($"[dim]Git output: {output}[/]");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(error))
+                    {
+                        AnsiConsole.MarkupLine($"[dim]Git stderr: {error}[/]");
+                    }
+
+                    // Verify that files were actually cloned (not just .git directory)
+                    if (Directory.Exists(localPath))
+                    {
+                        var files = Directory.GetFileSystemEntries(localPath, "*", SearchOption.TopDirectoryOnly)
+                            .Where(entry => !Path.GetFileName(entry).Equals(".git", StringComparison.OrdinalIgnoreCase))
+                            .ToArray();
+                        
+                        if (files.Length == 0)
+                        {
+                            AnsiConsole.MarkupLine($"[yellow]Warning: Clone completed but no files found in working directory. Attempting to checkout files...[/]");
+                            
+                            // Try to manually checkout the HEAD to ensure files are present
+                            var checkoutSuccess = await CheckoutFilesAsync(localPath, branchToUse, cancellationToken);
+                            if (!checkoutSuccess)
+                            {
+                                AnsiConsole.MarkupLine($"[red]Failed to checkout files. This might be an empty repository or the branch might not contain any files.[/]");
+                            }
+                        }
+                    }
+
+                    return true;
+                });
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error during git clone:[/] {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task<string?> DetermineBestBranchAsync(string remoteUrl, string? preferredBranch)
+    {
+        // If a specific branch is requested, use it
+        if (!string.IsNullOrEmpty(preferredBranch))
+        {
+            return preferredBranch;
+        }
+
+        // Try to get remote branches and find main/master
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"ls-remote --heads {remoteUrl}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+
+            var output = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+            {
+                var branches = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(line => line.Split('\t').LastOrDefault()?.Replace("refs/heads/", ""))
+                    .Where(branch => !string.IsNullOrEmpty(branch))
+                    .ToList();
+
+                // Prefer main over master (more common nowadays)
+                if (branches.Contains("main"))
+                    return "main";
+                if (branches.Contains("master"))
+                    return "master";
+            }
+        }
+        catch
+        {
+            // If remote branch detection fails, just proceed without specifying branch
+        }
+
+        return null;
+    }
+
+    public bool IsGitInstalled()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public bool IsDirectoryEmpty(string path)
+    {
+        if (!Directory.Exists(path))
+            return true;
+
+        return !Directory.EnumerateFileSystemEntries(path).Any();
+    }
+
+    private async Task<bool> CheckoutFilesAsync(string localPath, string? branch, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "checkout .",
+                WorkingDirectory = localPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = new Process { StartInfo = startInfo };
+            
+            // Register cancellation to kill the process
+            using var cancellationRegistration = cancellationToken.Register(() =>
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(true); // Kill entire process tree
+                    }
+                }
+                catch
+                {
+                    // Ignore errors during cleanup
+                }
+            });
+            
+            process.Start();
+
+            var output = await process.StandardOutput.ReadToEndAsync();
+            var error = await process.StandardError.ReadToEndAsync();
+            
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                AnsiConsole.MarkupLine($"[dim]Checkout failed: {error}[/]");
+                return false;
+            }
+
+            AnsiConsole.MarkupLine($"[green]Successfully checked out files.[/]");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[dim]Checkout error: {ex.Message}[/]");
+            return false;
+        }
+    }
+} 


### PR DESCRIPTION
Introduces commands for managing local sources and switching .csproj references between local project references and NuGet package references. Adds configuration for local sources, a service for manipulating csproj files, and supporting commands for configuring, switching to local, and switching back to package references.


---

_**Cursor** written code, careful review needed..._