### PR TITLE
Add build duration tracking to the build command

### DIFF
--- a/src/AbpDevTools/AbpDevTools.csproj
+++ b/src/AbpDevTools/AbpDevTools.csproj
@@ -36,4 +36,8 @@
     <None Include="..\..\art\logo_128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="AbpDevTools.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/AbpDevTools/Commands/BuildCommand.cs
+++ b/src/AbpDevTools/Commands/BuildCommand.cs
@@ -1,4 +1,4 @@
-﻿using AbpDevTools.Configuration;
+using AbpDevTools.Configuration;
 using AbpDevTools.Notifications;
 using CliFx.Infrastructure;
 using Spectre.Console;
@@ -58,6 +58,8 @@ public class BuildCommand : ICommand
             return;
         }
 
+        var totalStopwatch = Stopwatch.StartNew();
+
         var successfulCount = await AnsiConsole.Status().StartAsync("Starting build...", async ctx =>
         {
             int completed = 0;
@@ -75,6 +77,7 @@ public class BuildCommand : ICommand
                 }
 
                 var tools = toolsConfiguration.GetOptions();
+                var stepStopwatch = Stopwatch.StartNew();
                 
                 try
                 {
@@ -92,7 +95,6 @@ public class BuildCommand : ICommand
                         continue;
                     }
 
-                    // Capture both standard output and error streams
                     var outputTask = runningProcess.StandardOutput.ReadToEndAsync();
                     var errorTask = runningProcess.StandardError.ReadToEndAsync();
                     
@@ -101,33 +103,30 @@ public class BuildCommand : ICommand
                     var _output = await outputTask;
                     var _error = await errorTask;
 
+                    stepStopwatch.Stop();
+                    var stepDuration = FormatDuration(stepStopwatch.Elapsed);
+
                     if (runningProcess.ExitCode == 0)
                     {
                         completed++;
-                        AnsiConsole.MarkupLine($"{progressRatio} - [green]completed[/] [bold]Building[/] [silver]{buildFile.Name}[/]");
+                        AnsiConsole.MarkupLine($"{progressRatio} - [green]completed[/] [bold]Building[/] [silver]{buildFile.Name}[/] [grey]in {stepDuration}[/]");
                     }
                     else
                     {
-                        // Show failure status in red, but don't use markup for the build output
-                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} Exit Code: {runningProcess.ExitCode}");
+                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} Exit Code: {runningProcess.ExitCode} [grey]in {stepDuration}[/]");
                         
-                        // Write build output using AnsiConsole but with escaped content to avoid markup interpretation
                         AnsiConsole.WriteLine();
                         AnsiConsole.MarkupLine($"[red]Build failed for: {Markup.Escape(buildFile.Name)}[/]");
                         
-                        // Display standard output if available - escape content to prevent markup interpretation
                         if (!string.IsNullOrWhiteSpace(_output))
                         {
                             AnsiConsole.MarkupLine("[grey]Standard Output:[/]");
-                            // Write raw output without any markup interpretation
                             AnsiConsole.WriteLine(Markup.Escape(_output));
                         }
                         
-                        // Display error output if available - escape content to prevent markup interpretation
                         if (!string.IsNullOrWhiteSpace(_error))
                         {
                             AnsiConsole.MarkupLine("[red]Error Output:[/]");
-                            // Write raw error output without any markup interpretation
                             AnsiConsole.WriteLine(Markup.Escape(_error));
                         }
                         
@@ -136,12 +135,13 @@ public class BuildCommand : ICommand
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} - Exception: {Markup.Escape(ex.Message)}");
+                    stepStopwatch.Stop();
+                    var stepDuration = FormatDuration(stepStopwatch.Elapsed);
+                    AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} - Exception: {Markup.Escape(ex.Message)} [grey]in {stepDuration}[/]");
                     AnsiConsole.WriteLine();
                 }
                 finally
                 {
-                    // Ensure process cleanup
                     try
                     {
                         if (runningProcess != null && !runningProcess.HasExited)
@@ -151,7 +151,6 @@ public class BuildCommand : ICommand
                     }
                     catch (Exception)
                     {
-                        // Ignore cleanup exceptions
                     }
                 }
 
@@ -164,13 +163,18 @@ public class BuildCommand : ICommand
             return completed;
         });
 
+        totalStopwatch.Stop();
+        var totalDuration = FormatDuration(totalStopwatch.Elapsed);
+
+        AnsiConsole.MarkupLine($"[bold]Total build time:[/] [blue]{totalDuration}[/]");
+
         if (buildFiles.Length == 1)
         {
-            await notificationManager.SendAsync("Build "+ (successfulCount > 0 ? "Completed!" : "Failed!"), $"{buildFiles[0].Name} has been built.");
+            await notificationManager.SendAsync("Build "+ (successfulCount > 0 ? "Completed!" : "Failed!"), $"{buildFiles[0].Name} has been built in {totalDuration}.");
         }
         else
         {
-            await notificationManager.SendAsync("Build Done!", $"{successfulCount} of {buildFiles.Length} projects have been built in '{WorkingDirectory}' folder.");
+            await notificationManager.SendAsync("Build Done!", $"{successfulCount} of {buildFiles.Length} projects have been built in '{WorkingDirectory}' folder in {totalDuration}.");
         }
 
         cancellationToken.Register(KillRunningProcesses);
@@ -230,5 +234,20 @@ public class BuildCommand : ICommand
         runningProcess?.Kill(entireProcessTree: true);
 
         runningProcess?.WaitForExit();
+    }
+
+    private static string FormatDuration(TimeSpan elapsed)
+    {
+        if (elapsed.TotalHours >= 1)
+        {
+            return $"{(int)elapsed.TotalHours}h {elapsed.Minutes:D2}m {elapsed.Seconds:D2}s";
+        }
+
+        if (elapsed.TotalMinutes >= 1)
+        {
+            return $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
+        }
+
+        return $"{elapsed.Seconds}.{elapsed.Milliseconds / 100}s";
     }
 }

--- a/src/AbpDevTools/Commands/BuildCommand.cs
+++ b/src/AbpDevTools/Commands/BuildCommand.cs
@@ -91,7 +91,8 @@ public class BuildCommand : ICommand
 
                     if (runningProcess == null)
                     {
-                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} - Could not start process");
+                        stepStopwatch.Stop();
+                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {Markup.Escape(buildFile.Name)} - Could not start process [grey]in {FormatDuration(stepStopwatch.Elapsed)}[/]");
                         continue;
                     }
 
@@ -109,11 +110,11 @@ public class BuildCommand : ICommand
                     if (runningProcess.ExitCode == 0)
                     {
                         completed++;
-                        AnsiConsole.MarkupLine($"{progressRatio} - [green]completed[/] [bold]Building[/] [silver]{buildFile.Name}[/] [grey]in {stepDuration}[/]");
+                        AnsiConsole.MarkupLine($"{progressRatio} - [green]completed[/] [bold]Building[/] [silver]{Markup.Escape(buildFile.Name)}[/] [grey]in {stepDuration}[/]");
                     }
                     else
                     {
-                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} Exit Code: {runningProcess.ExitCode} [grey]in {stepDuration}[/]");
+                        AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {Markup.Escape(buildFile.Name)} Exit Code: {runningProcess.ExitCode} [grey]in {stepDuration}[/]");
                         
                         AnsiConsole.WriteLine();
                         AnsiConsole.MarkupLine($"[red]Build failed for: {Markup.Escape(buildFile.Name)}[/]");
@@ -137,7 +138,7 @@ public class BuildCommand : ICommand
                 {
                     stepStopwatch.Stop();
                     var stepDuration = FormatDuration(stepStopwatch.Elapsed);
-                    AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {buildFile.Name} - Exception: {Markup.Escape(ex.Message)} [grey]in {stepDuration}[/]");
+                    AnsiConsole.MarkupLine($"{progressRatio} - [red]failed[/] [bold]Building[/] {Markup.Escape(buildFile.Name)} - Exception: {Markup.Escape(ex.Message)} [grey]in {stepDuration}[/]");
                     AnsiConsole.WriteLine();
                 }
                 finally
@@ -174,7 +175,7 @@ public class BuildCommand : ICommand
         }
         else
         {
-            await notificationManager.SendAsync("Build Done!", $"{successfulCount} of {buildFiles.Length} projects have been built in '{WorkingDirectory}' folder in {totalDuration}.");
+            await notificationManager.SendAsync("Build Done!", $"{successfulCount} of {buildFiles.Length} projects have been built in '{WorkingDirectory}' folder. Total time: {totalDuration}.");
         }
 
         cancellationToken.Register(KillRunningProcesses);
@@ -236,7 +237,7 @@ public class BuildCommand : ICommand
         runningProcess?.WaitForExit();
     }
 
-    private static string FormatDuration(TimeSpan elapsed)
+    internal static string FormatDuration(TimeSpan elapsed)
     {
         if (elapsed.TotalHours >= 1)
         {
@@ -248,6 +249,6 @@ public class BuildCommand : ICommand
             return $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
         }
 
-        return $"{elapsed.Seconds}.{elapsed.Milliseconds / 100}s";
+        return $"{Math.Round(elapsed.TotalSeconds, 1):0.0}s";
     }
 }

--- a/src/AbpDevTools/Commands/BuildCommand.cs
+++ b/src/AbpDevTools/Commands/BuildCommand.cs
@@ -249,6 +249,13 @@ public class BuildCommand : ICommand
             return $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
         }
 
-        return $"{Math.Round(elapsed.TotalSeconds, 1):0.0}s";
+        var roundedSeconds = Math.Round(elapsed.TotalSeconds, 1, MidpointRounding.AwayFromZero);
+
+        if (roundedSeconds >= 60.0)
+        {
+            return "1m 00s";
+        }
+
+        return roundedSeconds.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture) + "s";
     }
 }

--- a/tests/AbpDevTools.Tests/Commands/BuildCommand_FormatDurationTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/BuildCommand_FormatDurationTests.cs
@@ -10,6 +10,7 @@ public class BuildCommand_FormatDurationTests
     [InlineData(0, 0, "0.0s")]
     [InlineData(0, 500, "0.5s")]
     [InlineData(0, 499, "0.5s")]
+    [InlineData(0, 50, "0.1s")]
     [InlineData(0, 100, "0.1s")]
     [InlineData(3, 200, "3.2s")]
     [InlineData(45, 0, "45.0s")]
@@ -17,6 +18,13 @@ public class BuildCommand_FormatDurationTests
     {
         var elapsed = TimeSpan.FromMilliseconds(seconds * 1000 + ms);
         BuildCommand.FormatDuration(elapsed).Should().Be(expected);
+    }
+
+    [Fact]
+    public void FormatDuration_RoundingTo60Seconds_ReturnsOneMinute()
+    {
+        var elapsed = TimeSpan.FromMilliseconds(59_950);
+        BuildCommand.FormatDuration(elapsed).Should().Be("1m 00s");
     }
 
     [Theory]

--- a/tests/AbpDevTools.Tests/Commands/BuildCommand_FormatDurationTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/BuildCommand_FormatDurationTests.cs
@@ -1,0 +1,42 @@
+using AbpDevTools.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace AbpDevTools.Tests.Commands;
+
+public class BuildCommand_FormatDurationTests
+{
+    [Theory]
+    [InlineData(0, 0, "0.0s")]
+    [InlineData(0, 500, "0.5s")]
+    [InlineData(0, 499, "0.5s")]
+    [InlineData(0, 100, "0.1s")]
+    [InlineData(3, 200, "3.2s")]
+    [InlineData(45, 0, "45.0s")]
+    public void FormatDuration_UnderOneMinute_ReturnsSeconds(int seconds, int ms, string expected)
+    {
+        var elapsed = TimeSpan.FromMilliseconds(seconds * 1000 + ms);
+        BuildCommand.FormatDuration(elapsed).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 0, "1m 00s")]
+    [InlineData(1, 5, "1m 05s")]
+    [InlineData(2, 15, "2m 15s")]
+    [InlineData(59, 59, "59m 59s")]
+    public void FormatDuration_MinutesRange_ReturnsMinutesAndSeconds(int minutes, int seconds, string expected)
+    {
+        var elapsed = TimeSpan.FromSeconds(minutes * 60 + seconds);
+        BuildCommand.FormatDuration(elapsed).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0, "1h 00m 00s")]
+    [InlineData(1, 5, 30, "1h 05m 30s")]
+    [InlineData(2, 30, 45, "2h 30m 45s")]
+    public void FormatDuration_HoursRange_ReturnsHoursMinutesAndSeconds(int hours, int minutes, int seconds, string expected)
+    {
+        var elapsed = TimeSpan.FromSeconds(hours * 3600 + minutes * 60 + seconds);
+        BuildCommand.FormatDuration(elapsed).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- Show elapsed time for each individual build step (displayed in grey after the completion/failure status)
- Display total build time at the end of all builds in blue
- Include duration in desktop notification messages
- Human-friendly formatting: `3.2s`, `2m 15s`, `1h 05m 30s` depending on magnitude

### Example output

`	ext
1/3 - completed Building MyApp.sln in 1m 23s
2/3 - failed Building OtherApp.sln Exit Code: 1 in 45.3s
3/3 - completed Building ThirdApp.sln in 2m 05s
Total build time: 4m 13s
`

Made with [Cursor](https://cursor.com)