### PR TITLE
Handle redirected console execution safely

### DIFF
--- a/src/AbpDevTools/AbpDevTools.csproj
+++ b/src/AbpDevTools/AbpDevTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageIcon>logo_128.png</PackageIcon>

--- a/src/AbpDevTools/Commands/LogsClearCommand.cs
+++ b/src/AbpDevTools/Commands/LogsClearCommand.cs
@@ -93,7 +93,11 @@ public class LogsClearCommand : ICommand
             var filePath = Path.Combine(logsDir, "logs.txt");
             if (File.Exists(filePath))
             {
-                if (!Force && !AnsiConsole.Confirm($"{filePath} will be deleted. Are you sure?"))
+                if (!Force && !global::AbpDevTools.ConsoleSupport.ConfirmOrDefault(
+                    console,
+                    $"{filePath} will be deleted. Are you sure?",
+                    defaultValue: false,
+                    fallbackMessage: $"Interactive confirmation is unavailable; '{filePath}' was not deleted. Pass '--force' to delete logs non-interactively."))
                 {
                     return;
                 }

--- a/src/AbpDevTools/Commands/MigrateCommand.cs
+++ b/src/AbpDevTools/Commands/MigrateCommand.cs
@@ -119,6 +119,8 @@ public class MigrateCommand : ICommand
 
     protected async Task RunParameterMigrationFallbackAsync()
     {
+        var canUseInteractiveConsole = global::AbpDevTools.ConsoleSupport.SupportsInteractiveConsole(console);
+
         FileInfo[] csprojs = await AnsiConsole.Status()
             .StartAsync("Looking for projects that support '--migrate-database' parameter...", async ctx =>
             {
@@ -135,9 +137,16 @@ public class MigrateCommand : ICommand
             return;
         }
 
-        
-        if (!AnsiConsole.Confirm("Do you want to run any of projects in this folder with '--migrate-database' parameter?"))
+        if (canUseInteractiveConsole)
         {
+            if (!AnsiConsole.Confirm("Do you want to run any of projects in this folder with '--migrate-database' parameter?"))
+            {
+                return;
+            }
+        }
+        else if (!RunAll && Projects.Length == 0)
+        {
+            await console!.Output.WriteLineAsync("Interactive migration confirmation is unavailable; skipping '--migrate-database' fallback projects. Pass '--all' or '--projects' to run them non-interactively.");
             return;
         }
 
@@ -147,18 +156,25 @@ public class MigrateCommand : ICommand
         {
             if (Projects.Length == 0)
             {
-                var selectedProjects = AnsiConsole.Prompt(
-                    new MultiSelectionPrompt<FileInfo>()
-                        .Title("Select project(s) to run with '--migrate-database' parameter")
-                        .Required(true)
-                        .PageSize(10)
-                        .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
-                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a project, [green]<enter>[/] to accept)[/]")
-                        .UseConverter(file => Path.GetRelativePath(WorkingDirectory!, file.FullName))
-                        .AddChoices(csprojs)
-                );
+                if (canUseInteractiveConsole)
+                {
+                    var selectedProjects = AnsiConsole.Prompt(
+                        new MultiSelectionPrompt<FileInfo>()
+                            .Title("Select project(s) to run with '--migrate-database' parameter")
+                            .Required(true)
+                            .PageSize(10)
+                            .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
+                            .InstructionsText("[grey](Press [blue]<space>[/] to toggle a project, [green]<enter>[/] to accept)[/]")
+                            .UseConverter(file => Path.GetRelativePath(WorkingDirectory!, file.FullName))
+                            .AddChoices(csprojs)
+                    );
 
-                projectFiles = selectedProjects.ToArray();
+                    projectFiles = selectedProjects.ToArray();
+                }
+                else
+                {
+                    await console!.Output.WriteLineAsync("Interactive migration project selection is unavailable; running all matching '--migrate-database' projects.");
+                }
             }
             else
             {
@@ -237,6 +253,12 @@ public class MigrateCommand : ICommand
 
     private async Task RenderStatusAsync()
     {
+        if (!global::AbpDevTools.ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            await RenderStatusWithoutInteractiveConsoleAsync();
+            return;
+        }
+
         var table = new Table().Border(TableBorder.Rounded);
 
         AnsiConsole.WriteLine(Environment.NewLine);
@@ -251,28 +273,70 @@ public class MigrateCommand : ICommand
 
                 foreach (var runningProject in runningProjects)
                 {
-                    runningProject.Process!.OutputDataReceived += (sender, args) =>
+                    AttachMigrationOutputReader(runningProject, _ =>
                     {
-                        if (args?.Data != null && args.Data.Length < 90)
-                        {
-                            var indexOfBracket = args.Data.IndexOf(']');
-                            if (indexOfBracket >= 0 && indexOfBracket < args.Data.Length)
-                            {
-                                runningProject.Status = args.Data[indexOfBracket..].Replace('[', '\0').Replace(']', '\0');
-                            }
-                            else
-                            {
-                                runningProject.Status = args.Data;
-                            }
-                            UpdateTable(table);
-                            ctx.UpdateTarget(table);
-                        }
-                    };
-                    runningProject.Process.BeginOutputReadLine();
+                        UpdateTable(table);
+                        ctx.UpdateTarget(table);
+                    });
                 }
 
                 await Task.WhenAll(runningProjects.Select(x => x.Process!.WaitForExitAsync()));
             });
+    }
+
+    private async Task RenderStatusWithoutInteractiveConsoleAsync()
+    {
+        var lastStatuses = new Dictionary<RunningProjectItem, string?>();
+        var statusLock = new object();
+
+        await console!.Output.WriteLineAsync("Interactive console features are unavailable; streaming migration status updates without the live dashboard.");
+
+        foreach (var runningProject in runningProjects)
+        {
+            lastStatuses[runningProject] = runningProject.Status;
+            await console.Output.WriteLineAsync($"- {runningProject.Name}: {runningProject.Status}");
+
+            AttachMigrationOutputReader(runningProject, project =>
+            {
+                lock (statusLock)
+                {
+                    if (lastStatuses.TryGetValue(project, out var lastStatus) && string.Equals(lastStatus, project.Status, StringComparison.Ordinal))
+                    {
+                        return;
+                    }
+
+                    lastStatuses[project] = project.Status;
+                    console.Output.WriteLine($"- {project.Name}: {project.Status}");
+                }
+            });
+        }
+
+        await Task.WhenAll(runningProjects.Select(x => x.Process!.WaitForExitAsync()));
+    }
+
+    private void AttachMigrationOutputReader(RunningProjectItem runningProject, Action<RunningProjectItem> onStatusChanged)
+    {
+        runningProject.Process!.OutputDataReceived += (sender, args) =>
+        {
+            if (args?.Data == null || args.Data.Length >= 90)
+            {
+                return;
+            }
+
+            var indexOfBracket = args.Data.IndexOf(']');
+            if (indexOfBracket >= 0 && indexOfBracket < args.Data.Length)
+            {
+                runningProject.Status = args.Data[indexOfBracket..].Replace('[', '\0').Replace(']', '\0');
+            }
+            else
+            {
+                runningProject.Status = args.Data;
+            }
+
+            onStatusChanged(runningProject);
+        };
+
+        runningProject.Process.BeginOutputReadLine();
     }
 
     private void UpdateTable(Table table)

--- a/src/AbpDevTools/Commands/MigrateCommand.cs
+++ b/src/AbpDevTools/Commands/MigrateCommand.cs
@@ -137,16 +137,12 @@ public class MigrateCommand : ICommand
             return;
         }
 
-        if (canUseInteractiveConsole)
+        if (!RunAll && Projects.Length == 0 && !global::AbpDevTools.ConsoleSupport.ConfirmOrDefault(
+            console,
+            "Do you want to run any of projects in this folder with '--migrate-database' parameter?",
+            defaultValue: false,
+            fallbackMessage: "Interactive migration confirmation is unavailable; skipping '--migrate-database' fallback projects. Pass '--all' or '--projects' to run them non-interactively."))
         {
-            if (!AnsiConsole.Confirm("Do you want to run any of projects in this folder with '--migrate-database' parameter?"))
-            {
-                return;
-            }
-        }
-        else if (!RunAll && Projects.Length == 0)
-        {
-            await console!.Output.WriteLineAsync("Interactive migration confirmation is unavailable; skipping '--migrate-database' fallback projects. Pass '--all' or '--projects' to run them non-interactively.");
             return;
         }
 

--- a/src/AbpDevTools/Commands/RunCommand.cs
+++ b/src/AbpDevTools/Commands/RunCommand.cs
@@ -96,6 +96,7 @@ public partial class RunCommand : ICommand
     public async ValueTask ExecuteAsync(IConsole console)
     {
         this.console = console;
+        var canUseInteractiveConsole = global::AbpDevTools.ConsoleSupport.SupportsInteractiveConsole(console);
 
         if (string.IsNullOrEmpty(WorkingDirectory))
         {
@@ -149,19 +150,26 @@ public partial class RunCommand : ICommand
 
             if (Projects.Length == 0)
             {
-                var choosedProjects = AnsiConsole.Prompt(
-                    new MultiSelectionPrompt<string>()
-                        .Title("Choose [mediumpurple2]projects[/] to run.")
-                        .Required(true)
-                        .PageSize(12)
-                        .HighlightStyle(new Style(foreground: Color.MediumPurple2))
-                        .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
-                        .InstructionsText(
-                            "[grey](Press [mediumpurple2]<space>[/] to toggle a project, " +
-                            "[green]<enter>[/] to accept)[/]")
-                        .AddChoices(projectFiles.Select(s => s.Name)));
+                if (canUseInteractiveConsole)
+                {
+                    var choosedProjects = AnsiConsole.Prompt(
+                        new MultiSelectionPrompt<string>()
+                            .Title("Choose [mediumpurple2]projects[/] to run.")
+                            .Required(true)
+                            .PageSize(12)
+                            .HighlightStyle(new Style(foreground: Color.MediumPurple2))
+                            .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
+                            .InstructionsText(
+                                "[grey](Press [mediumpurple2]<space>[/] to toggle a project, " +
+                                "[green]<enter>[/] to accept)[/]")
+                            .AddChoices(projectFiles.Select(s => s.Name)));
 
-                projectFiles = projectFiles.Where(x => choosedProjects.Contains(x.Name)).ToArray();
+                    projectFiles = projectFiles.Where(x => choosedProjects.Contains(x.Name)).ToArray();
+                }
+                else
+                {
+                    await console.Output.WriteLineAsync("Interactive project selection is unavailable; running all discovered projects. Use '--projects' to limit the selection.");
+                }
             }
             else
             {
@@ -192,9 +200,16 @@ public partial class RunCommand : ICommand
                 await console.Output.WriteLineAsync($"\n[yellow]Warning: The following projects are missing wwwroot/libs:[/]");
                 await console.Output.WriteLineAsync($"  - {projectList}");
 
-                if (AnsiConsole.Confirm("\n[yellow]Would you like to install libs for these projects?[/]"))
+                if (canUseInteractiveConsole)
                 {
-                    shouldInstallLibs = true;
+                    if (AnsiConsole.Confirm("\n[yellow]Would you like to install libs for these projects?[/]"))
+                    {
+                        shouldInstallLibs = true;
+                    }
+                }
+                else if (!shouldInstallLibs)
+                {
+                    await console.Output.WriteLineAsync("Interactive confirmation is unavailable; skipping 'abp install-libs'. Pass '--install-libs' to run it automatically.");
                 }
             }
         }
@@ -273,7 +288,7 @@ public partial class RunCommand : ICommand
 
             cancellationToken.Register(KillRunningProcesses);
 
-            await RenderProcesses(cancellationToken);
+            await RenderProcesses(cancellationToken, canUseInteractiveConsole);
 
             await updateCheckCommand.SoftCheckAsync(console);
         }
@@ -328,8 +343,14 @@ public partial class RunCommand : ICommand
         return Watch ? "watch " : string.Empty;
     }
 
-    private async Task RenderProcesses(CancellationToken cancellationToken)
+    private async Task RenderProcesses(CancellationToken cancellationToken, bool canUseInteractiveConsole)
     {
+        if (!canUseInteractiveConsole)
+        {
+            await RenderProcessesWithoutInteractiveConsole(cancellationToken);
+            return;
+        }
+
         var keyCommandHandler = new KeyCommandHandler(runningProjects, console!, cancellationToken);
 
         // Start key input listening
@@ -448,6 +469,52 @@ public partial class RunCommand : ICommand
         keyInputManager.StopListening();
     }
 
+    protected virtual async Task RenderProcessesWithoutInteractiveConsole(CancellationToken cancellationToken)
+    {
+        var lastStatuses = new Dictionary<RunningProjectItem, string?>();
+
+        await console!.Output.WriteLineAsync("Interactive console features are unavailable; live dashboard and keybindings are disabled.");
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var hasActiveProcesses = false;
+
+            foreach (var project in runningProjects)
+            {
+                UpdateProjectStatusForNonInteractiveMode(project, cancellationToken);
+
+                if (IsProjectActive(project))
+                {
+                    hasActiveProcesses = true;
+                }
+
+                if (!lastStatuses.TryGetValue(project, out var lastStatus) || !string.Equals(lastStatus, project.Status, StringComparison.Ordinal))
+                {
+                    await console.Output.WriteLineAsync($"- {project.Name}: {project.Status}");
+                    lastStatuses[project] = project.Status;
+                }
+            }
+
+            if (!hasActiveProcesses)
+            {
+                break;
+            }
+
+            try
+            {
+#if DEBUG
+                await Task.Delay(100, cancellationToken);
+#else
+                await Task.Delay(500, cancellationToken);
+#endif
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
     private static async Task RestartProject(RunningProjectItem project, CancellationToken cancellationToken = default)
     {
         project.Queued = true;
@@ -498,6 +565,34 @@ public partial class RunCommand : ICommand
         return string.Join(" | ", keyCommandHandler.KeyCommandMappings.Select(kcm => $"[grey]{kcm.GetKeyDisplay()}[/] - {kcm.Name}"));
     }
 
+    private void UpdateProjectStatusForNonInteractiveMode(RunningProjectItem project, CancellationToken cancellationToken)
+    {
+        if (project.Process is null || !project.Process.HasExited || project.Queued)
+        {
+            return;
+        }
+
+        if (project is RunningInstallLibsItem && project.IsCompleted)
+        {
+            return;
+        }
+
+        project.IsCompleted = false;
+        project.Status = Retry
+            ? $"[orange1]*[/] Exited({project.Process.ExitCode})"
+            : $"[red]*[/] Exited({project.Process.ExitCode})";
+
+        if (Retry)
+        {
+            _ = RestartProject(project, cancellationToken);
+        }
+    }
+
+    private static bool IsProjectActive(RunningProjectItem project)
+    {
+        return project.Queued || project.Process?.HasExited == false;
+    }
+
     protected void KillRunningProcesses()
     {
         // Ensure this is only executed once, even if called from multiple handlers
@@ -539,10 +634,15 @@ public partial class RunCommand : ICommand
 
     protected virtual void ClearConsoleIfNeeded()
     {
-        if (lastWindowWidth != Console.WindowWidth)
+        if (!global::AbpDevTools.ConsoleSupport.TryGetWindowWidth(console, out var currentWindowWidth))
+        {
+            return;
+        }
+
+        if (lastWindowWidth != currentWindowWidth)
         {
             AnsiConsole.Clear();
-            lastWindowWidth = Console.WindowWidth;
+            lastWindowWidth = currentWindowWidth;
         }
     }
 }

--- a/src/AbpDevTools/Commands/RunCommand.cs
+++ b/src/AbpDevTools/Commands/RunCommand.cs
@@ -200,16 +200,13 @@ public partial class RunCommand : ICommand
                 await console.Output.WriteLineAsync($"\n[yellow]Warning: The following projects are missing wwwroot/libs:[/]");
                 await console.Output.WriteLineAsync($"  - {projectList}");
 
-                if (canUseInteractiveConsole)
+                if (!shouldInstallLibs)
                 {
-                    if (AnsiConsole.Confirm("\n[yellow]Would you like to install libs for these projects?[/]"))
-                    {
-                        shouldInstallLibs = true;
-                    }
-                }
-                else if (!shouldInstallLibs)
-                {
-                    await console.Output.WriteLineAsync("Interactive confirmation is unavailable; skipping 'abp install-libs'. Pass '--install-libs' to run it automatically.");
+                    shouldInstallLibs = global::AbpDevTools.ConsoleSupport.ConfirmOrDefault(
+                        console,
+                        "\n[yellow]Would you like to install libs for these projects?[/]",
+                        defaultValue: false,
+                        fallbackMessage: "Interactive confirmation is unavailable; skipping 'abp install-libs'. Pass '--install-libs' to run it automatically.");
                 }
             }
         }

--- a/src/AbpDevTools/Commands/UpdateCheckCommand.cs
+++ b/src/AbpDevTools/Commands/UpdateCheckCommand.cs
@@ -99,11 +99,11 @@ public class UpdateCheckCommand : ICommand
 
         if (!Yes)
         {
-            var confirm = AnsiConsole.Prompt(
-                new ConfirmationPrompt("Do you want to update now?")
-                {
-                    DefaultValue = true
-                });
+            var confirm = global::AbpDevTools.ConsoleSupport.ConfirmOrDefault(
+                console,
+                "Do you want to update now?",
+                defaultValue: false,
+                fallbackMessage: "Interactive confirmation is unavailable; update cancelled. Pass '--yes' to apply the update non-interactively.");
 
             if (!confirm)
             {

--- a/src/AbpDevTools/ConsoleSupport.cs
+++ b/src/AbpDevTools/ConsoleSupport.cs
@@ -1,0 +1,67 @@
+using CliFx.Infrastructure;
+
+namespace AbpDevTools;
+
+internal static class ConsoleSupport
+{
+    public static bool CanReadConsoleInput()
+    {
+        try
+        {
+            return !Console.IsInputRedirected;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    public static bool SupportsInteractiveConsole(IConsole? console)
+    {
+        if (console is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return !console.IsInputRedirected && !console.IsOutputRedirected && !console.IsErrorRedirected;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    public static bool TryGetWindowWidth(IConsole? console, out int windowWidth)
+    {
+        windowWidth = 0;
+
+        if (!SupportsInteractiveConsole(console))
+        {
+            return false;
+        }
+
+        try
+        {
+            windowWidth = console!.WindowWidth;
+            return windowWidth > 0;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/AbpDevTools/ConsoleSupport.cs
+++ b/src/AbpDevTools/ConsoleSupport.cs
@@ -1,9 +1,20 @@
 using CliFx.Infrastructure;
+using Spectre.Console;
 
 namespace AbpDevTools;
 
 internal static class ConsoleSupport
 {
+    public static bool ConfirmOrDefault(IConsole? console, string prompt, bool defaultValue = true, string? fallbackMessage = null)
+    {
+        return ConfirmOrDefault(
+            console,
+            prompt,
+            defaultValue,
+            fallbackMessage,
+            (text, value) => AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = value }));
+    }
+
     public static bool CanReadConsoleInput()
     {
         try
@@ -63,5 +74,34 @@ internal static class ConsoleSupport
         {
             return false;
         }
+    }
+
+    internal static bool ConfirmOrDefault(
+        IConsole? console,
+        string prompt,
+        bool defaultValue,
+        string? fallbackMessage,
+        Func<string, bool, bool> confirm)
+    {
+        if (!SupportsInteractiveConsole(console))
+        {
+            if (!string.IsNullOrWhiteSpace(fallbackMessage) && console != null)
+            {
+                try
+                {
+                    console.Output.WriteLine(fallbackMessage);
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+            }
+
+            return defaultValue;
+        }
+
+        return confirm(prompt, defaultValue);
     }
 }

--- a/src/AbpDevTools/Services/KeyInputManager.cs
+++ b/src/AbpDevTools/Services/KeyInputManager.cs
@@ -7,15 +7,39 @@ public class KeyInputManager : IKeyInputManager, IDisposable
     public event EventHandler<KeyPressEventArgs>? KeyPressed;
     
     private readonly ConcurrentQueue<KeyPressEventArgs> _keyQueue = new();
+    private readonly Func<bool> _canReadConsoleInput;
+    private readonly Func<bool> _isKeyAvailable;
+    private readonly Func<ConsoleKeyInfo> _readKey;
     private CancellationTokenSource _cancellationTokenSource = new();
     private Task? _listeningTask;
     private bool _disposed;
 
     public bool IsListening => _listeningTask?.Status == TaskStatus.Running;
 
+    public KeyInputManager()
+        : this(
+            global::AbpDevTools.ConsoleSupport.CanReadConsoleInput,
+            () => Console.KeyAvailable,
+            () => Console.ReadKey(true))
+    {
+    }
+
+    internal KeyInputManager(
+        Func<bool> canReadConsoleInput,
+        Func<bool> isKeyAvailable,
+        Func<ConsoleKeyInfo> readKey)
+    {
+        _canReadConsoleInput = canReadConsoleInput;
+        _isKeyAvailable = isKeyAvailable;
+        _readKey = readKey;
+    }
+
     public void StartListening()
     {
         if (IsListening)
+            return;
+
+        if (!_canReadConsoleInput())
             return;
 
         // Ensure any previous listening task is fully stopped before starting a new one
@@ -45,9 +69,17 @@ public class KeyInputManager : IKeyInputManager, IDisposable
         {
             while (!_cancellationTokenSource.Token.IsCancellationRequested)
             {
-                if (Console.KeyAvailable)
+                if (!TryGetKeyAvailable(out var keyAvailable))
                 {
-                    var keyInfo = Console.ReadKey(true);
+                    return;
+                }
+
+                if (keyAvailable)
+                {
+                    if (!TryReadKey(out var keyInfo))
+                    {
+                        return;
+                    }
                     
                     var keyEventArgs = new KeyPressEventArgs
                     {
@@ -72,6 +104,44 @@ public class KeyInputManager : IKeyInputManager, IDisposable
         {
             // Log unexpected exceptions to aid debugging
             Console.Error.WriteLine($"[KeyInputManager] Unexpected exception: {ex}");
+        }
+    }
+
+    private bool TryGetKeyAvailable(out bool keyAvailable)
+    {
+        keyAvailable = false;
+
+        try
+        {
+            keyAvailable = _isKeyAvailable();
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    private bool TryReadKey(out ConsoleKeyInfo keyInfo)
+    {
+        keyInfo = default;
+
+        try
+        {
+            keyInfo = _readKey();
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
         }
     }
 

--- a/tests/AbpDevTools.Tests/Commands/RunCommand_NonInteractiveTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/RunCommand_NonInteractiveTests.cs
@@ -1,0 +1,158 @@
+using System.Text;
+using AbpDevTools.Commands;
+using AbpDevTools.Environments;
+using AbpDevTools.Notifications;
+using AbpDevTools.Services;
+using CliFx.Infrastructure;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace AbpDevTools.Tests.Commands;
+
+public class RunCommand_NonInteractiveTests
+{
+    [Fact]
+    public void ClearConsoleIfNeeded_WithRedirectedConsole_DoesNotTouchWindowWidth()
+    {
+        // Arrange
+        var command = new TestRunCommand();
+        var console = new TestConsole(isInputRedirected: true, isOutputRedirected: true, isErrorRedirected: true, throwOnWindowWidthAccess: true);
+        command.SetConsole(console);
+
+        // Act
+        var act = () => command.InvokeClearConsoleIfNeeded();
+
+        // Assert
+        act.Should().NotThrow("redirected consoles should skip console width checks entirely");
+    }
+
+    [Fact]
+    public async Task RenderProcessesWithoutInteractiveConsole_WritesStatusesAndReturns()
+    {
+        // Arrange
+        var command = new TestRunCommand();
+        var console = new TestConsole(isInputRedirected: true, isOutputRedirected: true, isErrorRedirected: true);
+        command.SetConsole(console);
+        command.AddProject(new RunningProjectItem
+        {
+            Name = "Sample.Web",
+            Status = "Building..."
+        });
+
+        // Act
+        await command.InvokeRenderProcessesWithoutInteractiveConsole(CancellationToken.None);
+
+        // Assert
+        var output = console.GetOutput();
+        output.Should().Contain("Interactive console features are unavailable");
+        output.Should().Contain("Sample.Web");
+        output.Should().Contain("Building...");
+    }
+
+    [CliFx.Attributes.Command("test-run-command")]
+    private sealed class TestRunCommand : RunCommand
+    {
+        public TestRunCommand()
+            : base(
+                Substitute.For<INotificationManager>(),
+                null!,
+                Substitute.For<IProcessEnvironmentManager>(),
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                Substitute.For<IKeyInputManager>())
+        {
+        }
+
+        public void SetConsole(IConsole console)
+        {
+            this.console = console;
+        }
+
+        public void AddProject(RunningProjectItem runningProject)
+        {
+            runningProjects.Add(runningProject);
+        }
+
+        public void InvokeClearConsoleIfNeeded()
+        {
+            ClearConsoleIfNeeded();
+        }
+
+        public Task InvokeRenderProcessesWithoutInteractiveConsole(CancellationToken cancellationToken)
+        {
+            return RenderProcessesWithoutInteractiveConsole(cancellationToken);
+        }
+    }
+
+    private sealed class TestConsole : IConsole
+    {
+        private readonly MemoryStream _inputStream = new();
+        private readonly MemoryStream _outputStream = new();
+        private readonly MemoryStream _errorStream = new();
+        private readonly Lazy<ConsoleReader> _input;
+        private readonly Lazy<ConsoleWriter> _output;
+        private readonly Lazy<ConsoleWriter> _error;
+        private readonly bool _throwOnWindowWidthAccess;
+        private int _windowWidth = 120;
+
+        public TestConsole(bool isInputRedirected, bool isOutputRedirected, bool isErrorRedirected, bool throwOnWindowWidthAccess = false)
+        {
+            IsInputRedirected = isInputRedirected;
+            IsOutputRedirected = isOutputRedirected;
+            IsErrorRedirected = isErrorRedirected;
+            _throwOnWindowWidthAccess = throwOnWindowWidthAccess;
+
+            _input = new Lazy<ConsoleReader>(() => new ConsoleReader(this, _inputStream, Encoding.UTF8));
+            _output = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _outputStream, Encoding.UTF8));
+            _error = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _errorStream, Encoding.UTF8));
+        }
+
+        public ConsoleReader Input => _input.Value;
+        public ConsoleWriter Output => _output.Value;
+        public ConsoleWriter Error => _error.Value;
+
+        public bool IsOutputRedirected { get; }
+        public bool IsErrorRedirected { get; }
+        public bool IsInputRedirected { get; }
+
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+
+        public int WindowWidth
+        {
+            get
+            {
+                if (_throwOnWindowWidthAccess)
+                {
+                    throw new InvalidOperationException("Window width is unavailable.");
+                }
+
+                return _windowWidth;
+            }
+            set => _windowWidth = value;
+        }
+
+        public int WindowHeight { get; set; } = 30;
+        public int CursorLeft { get; set; }
+        public int CursorTop { get; set; }
+
+        public CancellationToken RegisterCancellationHandler() => CancellationToken.None;
+        public ConsoleKeyInfo ReadKey(bool intercept = false) => default;
+        public void Clear() { }
+        public void ResetColor() { }
+
+        public string GetOutput()
+        {
+            if (_output.IsValueCreated)
+            {
+                _output.Value.Flush();
+            }
+
+            return Encoding.UTF8.GetString(_outputStream.ToArray());
+        }
+    }
+}

--- a/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
+++ b/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using CliFx.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace AbpDevTools.Tests;
+
+public class ConsoleSupportTests
+{
+    [Fact]
+    public void ConfirmOrDefault_WithRedirectedConsole_ReturnsDefaultAndWritesFallbackMessage()
+    {
+        // Arrange
+        var console = new TestConsole(isInputRedirected: true, isOutputRedirected: true, isErrorRedirected: true);
+
+        // Act
+        var result = ConsoleSupport.ConfirmOrDefault(
+            console,
+            "Continue?",
+            defaultValue: false,
+            fallbackMessage: "Using the safe default.",
+            confirm: (_, _) => throw new InvalidOperationException("Prompt callback should not run."));
+
+        // Assert
+        result.Should().BeFalse();
+        console.GetOutput().Should().Contain("Using the safe default.");
+    }
+
+    [Fact]
+    public void ConfirmOrDefault_WithInteractiveConsole_UsesPromptCallback()
+    {
+        // Arrange
+        var console = new TestConsole(isInputRedirected: false, isOutputRedirected: false, isErrorRedirected: false);
+        var callbackInvoked = false;
+
+        // Act
+        var result = ConsoleSupport.ConfirmOrDefault(
+            console,
+            "Continue?",
+            defaultValue: false,
+            fallbackMessage: "Should not be shown.",
+            confirm: (prompt, defaultValue) =>
+            {
+                callbackInvoked = true;
+                prompt.Should().Be("Continue?");
+                defaultValue.Should().BeFalse();
+                return true;
+            });
+
+        // Assert
+        result.Should().BeTrue();
+        callbackInvoked.Should().BeTrue();
+        console.GetOutput().Should().BeEmpty();
+    }
+
+    private sealed class TestConsole : IConsole
+    {
+        private readonly MemoryStream _inputStream = new();
+        private readonly MemoryStream _outputStream = new();
+        private readonly MemoryStream _errorStream = new();
+        private readonly Lazy<ConsoleReader> _input;
+        private readonly Lazy<ConsoleWriter> _output;
+        private readonly Lazy<ConsoleWriter> _error;
+        private int _windowWidth = 120;
+
+        public TestConsole(bool isInputRedirected, bool isOutputRedirected, bool isErrorRedirected)
+        {
+            IsInputRedirected = isInputRedirected;
+            IsOutputRedirected = isOutputRedirected;
+            IsErrorRedirected = isErrorRedirected;
+
+            _input = new Lazy<ConsoleReader>(() => new ConsoleReader(this, _inputStream, Encoding.UTF8));
+            _output = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _outputStream, Encoding.UTF8));
+            _error = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _errorStream, Encoding.UTF8));
+        }
+
+        public ConsoleReader Input => _input.Value;
+        public ConsoleWriter Output => _output.Value;
+        public ConsoleWriter Error => _error.Value;
+
+        public bool IsOutputRedirected { get; }
+        public bool IsErrorRedirected { get; }
+        public bool IsInputRedirected { get; }
+
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+        public int WindowWidth
+        {
+            get => _windowWidth;
+            set => _windowWidth = value;
+        }
+
+        public int WindowHeight { get; set; } = 30;
+        public int CursorLeft { get; set; }
+        public int CursorTop { get; set; }
+
+        public CancellationToken RegisterCancellationHandler() => CancellationToken.None;
+        public ConsoleKeyInfo ReadKey(bool intercept = false) => default;
+        public void Clear() { }
+        public void ResetColor() { }
+
+        public string GetOutput()
+        {
+            if (_output.IsValueCreated)
+            {
+                _output.Value.Flush();
+            }
+
+            return Encoding.UTF8.GetString(_outputStream.ToArray());
+        }
+    }
+}

--- a/tests/AbpDevTools.Tests/Services/KeyInputManagerTests.cs
+++ b/tests/AbpDevTools.Tests/Services/KeyInputManagerTests.cs
@@ -59,6 +59,40 @@ public class KeyInputManagerTests
     }
 
     [Fact]
+    public void StartListening_WithUnavailableConsoleInput_DoesNotStartListening()
+    {
+        // Arrange
+        using var manager = new KeyInputManager(
+            () => false,
+            () => false,
+            () => default);
+
+        // Act
+        manager.StartListening();
+
+        // Assert
+        manager.IsListening.Should().BeFalse("listening should remain disabled when console input is unavailable");
+    }
+
+    [Fact]
+    public async Task StartListening_WhenKeyPollingFails_StopsGracefully()
+    {
+        // Arrange
+        using var manager = new KeyInputManager(
+            () => true,
+            () => throw new InvalidOperationException("No console available"),
+            () => default);
+
+        // Act
+        manager.StartListening();
+        await Task.Delay(150);
+
+        // Assert
+        manager.IsListening.Should().BeFalse("the listener should stop when key polling is unavailable");
+        manager.TryGetNextKey().Should().BeNull("no key should be queued when polling fails");
+    }
+
+    [Fact]
     public void StopListening_DoesNotThrow()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- make `run` and migration execution safe when stdin/stdout are redirected by skipping key listeners, live console rendering, and raw terminal size checks
- add a shared confirmation fallback so commands use explicit safe defaults instead of assuming Spectre prompts can run without an interactive terminal
- add regression tests for redirected-console behavior in key input handling, run rendering, and confirmation fallbacks

## Testing
- `dotnet test \"tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj\" --filter \"FullyQualifiedName~ConsoleSupportTests|FullyQualifiedName~RunCommand_|FullyQualifiedName~MigrateCommandTests|FullyQualifiedName~KeyInputManagerTests\"`