### PR TITLE
Support wildcard file patterns in replace

### DIFF
--- a/src/AbpDevTools/Commands/ReplaceCommand.cs
+++ b/src/AbpDevTools/Commands/ReplaceCommand.cs
@@ -1,6 +1,7 @@
 ﻿using AbpDevTools.Configuration;
 using CliFx.Infrastructure;
 using Spectre.Console;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace AbpDevTools.Commands;
@@ -65,8 +66,7 @@ public class ReplaceCommand : ICommand
             {
                 // Use the union of all files matching any config's pattern
                 var allFiles = options.Values
-                    .SelectMany(opt => Directory.EnumerateFiles(WorkingDirectory!, "*.*", SearchOption.AllDirectories)
-                        .Where(x => Regex.IsMatch(x, opt.FilePattern)))
+                    .SelectMany(opt => GetFilesMatchingPattern(opt.FilePattern))
                     .Distinct()
                     .ToList();
                 var relToFull = allFiles.ToDictionary(
@@ -121,9 +121,7 @@ public class ReplaceCommand : ICommand
             await Task.Yield();
 
             ctx.Status($"[blue]{option.FilePattern}[/] file pattern executing.");
-            var allFiles = Directory.EnumerateFiles(WorkingDirectory!, "*.*", SearchOption.AllDirectories)
-                .Where(x => Regex.IsMatch(x, option.FilePattern))
-                .ToList();
+            var allFiles = GetFilesMatchingPattern(option.FilePattern);
 
             List<string> filesToProcess = allFiles;
 
@@ -158,20 +156,131 @@ public class ReplaceCommand : ICommand
 
             ctx.Status($"[green]{filesToProcess.Count}[/] file(s) selected for processing.");
 
-            int affectedFileCount = 0;
-            foreach (var file in filesToProcess)
-            {
-                var text = File.ReadAllText(file);
+            var affectedFileCount = ProcessFiles(filesToProcess, option, file => ctx.Status($"{file} updated."));
 
-                if (text.Contains(option.Find))
-                {
-                    File.WriteAllText(file, text.Replace(option.Find, option.Replace));
-                    ctx.Status($"{file} updated.");
-                    affectedFileCount++;
-                }
-            }
             AnsiConsole.MarkupLine($"Totally [green]{affectedFileCount}[/] files updated.");
         });
 
+    }
+
+    protected virtual List<string> GetFilesMatchingPattern(string filePattern)
+    {
+        return Directory.EnumerateFiles(WorkingDirectory!, "*.*", SearchOption.AllDirectories)
+            .Where(filePath => MatchesFilePattern(filePath, filePattern))
+            .ToList();
+    }
+
+    protected virtual int ProcessFiles(IEnumerable<string> filesToProcess, ReplacementOption option, Action<string>? onFileUpdated = null)
+    {
+        int affectedFileCount = 0;
+
+        foreach (var file in filesToProcess)
+        {
+            var text = File.ReadAllText(file);
+
+            if (!text.Contains(option.Find))
+            {
+                continue;
+            }
+
+            File.WriteAllText(file, text.Replace(option.Find, option.Replace));
+            onFileUpdated?.Invoke(file);
+            affectedFileCount++;
+        }
+
+        return affectedFileCount;
+    }
+
+    protected virtual bool MatchesFilePattern(string filePath, string filePattern)
+    {
+        if (LooksLikeRegex(filePattern))
+        {
+            var relativePath = NormalizePath(Path.GetRelativePath(WorkingDirectory!, filePath));
+            return Regex.IsMatch(relativePath, filePattern)
+                || Regex.IsMatch(Path.GetFileName(filePath), filePattern)
+                || Regex.IsMatch(filePath, filePattern);
+        }
+
+        var normalizedPattern = NormalizePath(filePattern);
+        var normalizedRelativePath = NormalizePath(Path.GetRelativePath(WorkingDirectory!, filePath));
+        var target = normalizedPattern.Contains('/')
+            ? normalizedRelativePath
+            : Path.GetFileName(filePath);
+
+        return Regex.IsMatch(target, ConvertGlobToRegex(normalizedPattern), RegexOptions.IgnoreCase);
+    }
+
+    private static bool LooksLikeRegex(string filePattern)
+    {
+        return filePattern.IndexOf('\\') >= 0
+            || filePattern.IndexOfAny(['^', '$', '+', '|', '(', ')', '[', ']']) >= 0;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Replace('\\', '/');
+    }
+
+    private static string ConvertGlobToRegex(string pattern)
+    {
+        var regex = new StringBuilder("^");
+
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            var character = pattern[i];
+
+            switch (character)
+            {
+                case '*':
+                    if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                    {
+                        var isDirectoryWildcard = i + 2 < pattern.Length && pattern[i + 2] == '/';
+
+                        if (isDirectoryWildcard)
+                        {
+                            regex.Append("(?:.*/)?");
+                            i += 2;
+                        }
+                        else
+                        {
+                            regex.Append(".*");
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        regex.Append("[^/]*");
+                    }
+                    break;
+                case '?':
+                    regex.Append("[^/]");
+                    break;
+                case '{':
+                    var closingBraceIndex = pattern.IndexOf('}', i + 1);
+
+                    if (closingBraceIndex > i)
+                    {
+                        var options = pattern[(i + 1)..closingBraceIndex]
+                            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                            .Select(Regex.Escape);
+
+                        regex.Append("(?:");
+                        regex.Append(string.Join('|', options));
+                        regex.Append(')');
+                        i = closingBraceIndex;
+                    }
+                    else
+                    {
+                        regex.Append("\\{");
+                    }
+                    break;
+                default:
+                    regex.Append(Regex.Escape(character.ToString()));
+                    break;
+            }
+        }
+
+        regex.Append('$');
+        return regex.ToString();
     }
 }

--- a/src/AbpDevTools/Configuration/ReplacementConfiguration.cs
+++ b/src/AbpDevTools/Configuration/ReplacementConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using YamlDotNet.Serialization;
+﻿using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
 
 namespace AbpDevTools.Configuration;
 
@@ -12,6 +13,21 @@ public class ReplacementConfiguration : ConfigurationBase<Dictionary<string, Rep
     public override string FileName => "replacements";
 
     protected override string LegacyJsonFilePath => Path.Combine(FolderPath, "replacements.json");
+
+    public override Dictionary<string, ReplacementOption> GetOptions()
+    {
+        NormalizeWildcardFilePatternsInConfig();
+        return base.GetOptions()!;
+    }
+
+    protected virtual string NormalizeWildcardFilePatterns(string yamlContent)
+    {
+        return Regex.Replace(
+            yamlContent,
+            "(?m)^(\\s*file-pattern\\s*:\\s*)(?!['\"])(\\*[^#\\r\\n]*)(\\s*(?:#.*)?)$",
+            match => $"{match.Groups[1].Value}\"{match.Groups[2].Value.TrimEnd()}\"{match.Groups[3].Value}"
+        );
+    }
 
     protected override Dictionary<string, ReplacementOption> GetDefaults()
     {
@@ -34,5 +50,21 @@ public class ReplacementConfiguration : ConfigurationBase<Dictionary<string, Rep
                 }
             }
         };
+    }
+
+    private void NormalizeWildcardFilePatternsInConfig()
+    {
+        if (!File.Exists(FilePath))
+        {
+            return;
+        }
+
+        var yamlContent = File.ReadAllText(FilePath);
+        var normalizedYamlContent = NormalizeWildcardFilePatterns(yamlContent);
+
+        if (!string.Equals(yamlContent, normalizedYamlContent, StringComparison.Ordinal))
+        {
+            File.WriteAllText(FilePath, normalizedYamlContent);
+        }
     }
 }

--- a/tests/AbpDevTools.Tests/Commands/ReplaceCommandTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/ReplaceCommandTests.cs
@@ -329,6 +329,122 @@ public class ReplaceCommandTests : CommandTestBase
 
     #endregion
 
+    #region Wildcard File Pattern Tests
+
+    [Fact]
+    public void ReplaceCommand_Matches_Asterisk_Glob_File_Patterns()
+    {
+        var workingDirectory = CreateTempWorkingDirectory();
+
+        try
+        {
+            var rootProject = Path.Combine(workingDirectory, "RootProject.csproj");
+            var nestedDirectory = Path.Combine(workingDirectory, "src");
+            var nestedProject = Path.Combine(nestedDirectory, "NestedProject.csproj");
+            var textFile = Path.Combine(workingDirectory, "notes.txt");
+
+            Directory.CreateDirectory(nestedDirectory);
+            File.WriteAllText(rootProject, "<Version>1.0.0</Version>");
+            File.WriteAllText(nestedProject, "<Version>1.0.0</Version>");
+            File.WriteAllText(textFile, "<Version>1.0.0</Version>");
+
+            var command = new TestableReplaceCommand(CreateMockReplacementConfiguration(new Dictionary<string, ReplacementOption>()))
+            {
+                WorkingDirectory = workingDirectory
+            };
+
+            var matchingFiles = command.GetFilesMatchingPatternPublic("*.csproj");
+
+            matchingFiles.Count.ShouldBe(2);
+            matchingFiles.ShouldContain(rootProject);
+            matchingFiles.ShouldContain(nestedProject);
+            matchingFiles.ShouldNotContain(textFile);
+        }
+        finally
+        {
+            CleanupWorkingDirectory(workingDirectory);
+        }
+    }
+
+    [Fact]
+    public void ReplaceCommand_Replaces_Files_Matched_By_Asterisk_Glob()
+    {
+        var workingDirectory = CreateTempWorkingDirectory();
+
+        try
+        {
+            var rootProject = Path.Combine(workingDirectory, "RootProject.csproj");
+            var nestedDirectory = Path.Combine(workingDirectory, "src");
+            var nestedProject = Path.Combine(nestedDirectory, "NestedProject.csproj");
+            var textFile = Path.Combine(workingDirectory, "notes.txt");
+
+            Directory.CreateDirectory(nestedDirectory);
+            File.WriteAllText(rootProject, "<Version>1.0.0</Version>");
+            File.WriteAllText(nestedProject, "<Version>1.0.0</Version>");
+            File.WriteAllText(textFile, "<Version>1.0.0</Version>");
+
+            var command = new TestableReplaceCommand(CreateMockReplacementConfiguration(new Dictionary<string, ReplacementOption>()))
+            {
+                WorkingDirectory = workingDirectory
+            };
+            var option = new ReplacementOption
+            {
+                FilePattern = "*.csproj",
+                Find = "<Version>1.0.0</Version>",
+                Replace = "<Version>2.0.0</Version>"
+            };
+
+            var matchingFiles = command.GetFilesMatchingPatternPublic(option.FilePattern);
+            var affectedFileCount = command.ProcessFilesPublic(matchingFiles, option);
+
+            affectedFileCount.ShouldBe(2);
+            File.ReadAllText(rootProject).ShouldContain(option.Replace);
+            File.ReadAllText(nestedProject).ShouldContain(option.Replace);
+            File.ReadAllText(textFile).ShouldContain(option.Find);
+        }
+        finally
+        {
+            CleanupWorkingDirectory(workingDirectory);
+        }
+    }
+
+    [Fact]
+    public void ReplaceCommand_Still_Matches_Regex_File_Patterns()
+    {
+        var workingDirectory = CreateTempWorkingDirectory();
+
+        try
+        {
+            var rootJson = Path.Combine(workingDirectory, "appsettings.json");
+            var nestedDirectory = Path.Combine(workingDirectory, "config");
+            var nestedJson = Path.Combine(nestedDirectory, "appsettings.Development.json");
+            var textFile = Path.Combine(workingDirectory, "notes.txt");
+
+            Directory.CreateDirectory(nestedDirectory);
+            File.WriteAllText(rootJson, "{}");
+            File.WriteAllText(nestedJson, "{}");
+            File.WriteAllText(textFile, "{}");
+
+            var command = new TestableReplaceCommand(CreateMockReplacementConfiguration(new Dictionary<string, ReplacementOption>()))
+            {
+                WorkingDirectory = workingDirectory
+            };
+
+            var matchingFiles = command.GetFilesMatchingPatternPublic(@".*\.json");
+
+            matchingFiles.Count.ShouldBe(2);
+            matchingFiles.ShouldContain(rootJson);
+            matchingFiles.ShouldContain(nestedJson);
+            matchingFiles.ShouldNotContain(textFile);
+        }
+        finally
+        {
+            CleanupWorkingDirectory(workingDirectory);
+        }
+    }
+
+    #endregion
+
     #region Test Helper Classes
 
     /// <summary>
@@ -345,6 +461,40 @@ public class ReplaceCommandTests : CommandTestBase
         mock.GetOptions().Returns(options);
 
         return mock;
+    }
+
+    private static string CreateTempWorkingDirectory()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), $"abpdev-replace-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        return workingDirectory;
+    }
+
+    private static void CleanupWorkingDirectory(string workingDirectory)
+    {
+        if (Directory.Exists(workingDirectory))
+        {
+            Directory.Delete(workingDirectory, true);
+        }
+    }
+
+    [CliFx.Attributes.Command("test-replace")]
+    private sealed class TestableReplaceCommand : ReplaceCommand
+    {
+        public TestableReplaceCommand(ReplacementConfiguration replacementConfiguration)
+            : base(replacementConfiguration)
+        {
+        }
+
+        public List<string> GetFilesMatchingPatternPublic(string filePattern)
+        {
+            return GetFilesMatchingPattern(filePattern);
+        }
+
+        public int ProcessFilesPublic(IEnumerable<string> filesToProcess, ReplacementOption option)
+        {
+            return ProcessFiles(filesToProcess, option);
+        }
     }
 
     #endregion

--- a/tests/AbpDevTools.Tests/Configuration/ReplacementConfigurationTests.cs
+++ b/tests/AbpDevTools.Tests/Configuration/ReplacementConfigurationTests.cs
@@ -194,6 +194,28 @@ RecursivePattern:
         result["RecursivePattern"].FilePattern.ShouldBe("**/*.config");
     }
 
+    [Fact]
+    public void Should_Normalize_Unquoted_FilePattern_Starting_With_Asterisk()
+    {
+        // Arrange
+        var yaml = @"
+ProjectFile:
+  file-pattern: *.csproj
+  find: old
+  replace: new
+";
+        var configuration = new TestReplacementConfiguration(YamlDeserializer, YamlSerializer);
+
+        // Act
+        var normalizedYaml = configuration.NormalizeYamlForTest(yaml);
+        var result = DeserializeYaml<Dictionary<string, ReplacementOption>>(normalizedYaml);
+
+        // Assert
+        normalizedYaml.ShouldContain("file-pattern: \"*.csproj\"");
+        result.ShouldNotBeNull();
+        result["ProjectFile"].FilePattern.ShouldBe("*.csproj");
+    }
+
     #endregion
 
     #region Empty Replacements
@@ -487,4 +509,17 @@ DollarSignReplacement:
     }
 
     #endregion
+
+    private sealed class TestReplacementConfiguration : ReplacementConfiguration
+    {
+        public TestReplacementConfiguration(YamlDotNet.Serialization.IDeserializer yamlDeserializer, YamlDotNet.Serialization.ISerializer yamlSerializer)
+            : base(yamlDeserializer, yamlSerializer)
+        {
+        }
+
+        public string NormalizeYamlForTest(string yamlContent)
+        {
+            return NormalizeWildcardFilePatterns(yamlContent);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support glob-style replace file patterns such as `*.csproj`, `appsettings*.json`, and `**/*.config` while keeping regex-style patterns working
- normalize unquoted wildcard `file-pattern` values before YAML deserialization so leading `*` markers are valid in replace configuration files
- add targeted tests for wildcard config parsing, wildcard file matching and replacement, and regex compatibility

## Testing
- `dotnet test "tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj" --no-restore --filter "FullyQualifiedName~ReplaceCommandTests|FullyQualifiedName~ReplacementConfigurationTests"`