### PR TITLE
Print logs to terminal by default and expand reusable skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ This command performs the following operations:
 - **Configuration**: Creates `abpdev.yml` files with appropriate environment settings
 
 ## abpdev logs
-Finds given project under the current directory and shows logs of it.
+Finds a project under the current directory and prints the last log lines to the terminal by default. Use `--open` to keep the old file/folder opening behavior.
 
 ![abpdev logs](images/abpdevlogs.gif)
 ---
@@ -351,11 +351,13 @@ Finds given project under the current directory and shows logs of it.
   abpdev logs [command] [...]
 
 PARAMETERS
-  projectname       Determines the project to open logs of it.
+  projectname       Determines the project to show logs of.
 
 OPTIONS
   -p|--path         Working directory of the command. Probably solution directory. Default: . (CurrentDirectory)
   -i|--interactive  Options will be asked as prompt when this option used. Default: "False".
+  -n|--lines        Number of lines to print from the end of logs.txt. Default: 100.
+  -o|--open         Opens logs with the operating system default app instead of printing them.
   -h|--help         Shows help text.
 
 COMMANDS
@@ -364,9 +366,19 @@ COMMANDS
 
 ### Example commands
 
-- Show logs of the **.Web** project
+- Show the last 100 log lines of the **.Web** project
     ```bash
     abpdev logs Web
+    ```
+
+- Show the last 20 log lines
+    ```bash
+    abpdev logs Web -n 20
+    ```
+
+- Open the log file or folder with the operating system default app
+    ```bash
+    abpdev logs Web --open
     ```
 
 - Clear logs of the **.Web** project

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,22 @@ Pre-built instruction sets that teach AI coding assistants how to use [AbpDevToo
 
 | Skill | Description |
 |-------|-------------|
-| [abpdev-references](abpdev-references/SKILL.md) | Switch between NuGet packages and local project references (`abpdev references to-local`, `to-package`, config) |
+| [abpdev-add-package](abpdev-add-package/SKILL.md) | Add NuGet packages from any source and automatically wire ABP module dependencies (`abpdev add-package`) |
+| [abpdev-workflow](abpdev-workflow/SKILL.md) | Core developer workflow commands (`abpdev build`, `migrate`, `run`, `test`, `prepare`, `logs`, `bundle`) |
+| [abpdev-environments](abpdev-environments/SKILL.md) | Virtual environments and infra apps (`abpdev env`, `envapp`, `switch-to-env`) |
+| [abpdev-migrations](abpdev-migrations/SKILL.md) | EF Core migration and database workflows (`abpdev migrations`, `database-drop`) |
+| [abpdev-maintenance](abpdev-maintenance/SKILL.md) | Maintenance/utilities (`abpdev clean`, `replace`, `logs clear`, `tools`, `update`, `find-port`, etc.) |
+| [abpdev-references](abpdev-references/SKILL.md) | Switch between NuGet packages and local project references (`abpdev references to-local`, `to-package`, `references config`, `local-sources`) |
+
+## Recommended Granularity
+
+Prefer **one skill per reusable command family**, not one skill per individual leaf command and not one giant all-in-one `abpdev` skill.
+
+Use this rule of thumb:
+
+1. Create a separate skill when a command area has its own config, workflows, caveats, and troubleshooting.
+2. Group closely related commands that are usually used together, such as `run/build/test/prepare` or `migrations/*`.
+3. Avoid monolithic skills because agents have to fetch/read more than necessary and the instructions become harder to maintain.
 
 > **Base URL for raw downloads:**
 > ```
@@ -27,30 +42,34 @@ Cursor natively supports skills as `SKILL.md` files.
 
 ```powershell
 # Windows (PowerShell)
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.cursor\skills\abpdev-references" | Out-Null
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" -OutFile "$env:USERPROFILE\.cursor\skills\abpdev-references\SKILL.md"
+$skill = "abpdev-references"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.cursor\skills\$skill" | Out-Null
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" -OutFile "$env:USERPROFILE\.cursor\skills\$skill\SKILL.md"
 ```
 
 ```bash
 # macOS / Linux
-mkdir -p ~/.cursor/skills/abpdev-references
-curl -fsSL -o ~/.cursor/skills/abpdev-references/SKILL.md \
-  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md"
+skill="abpdev-references"
+mkdir -p ~/.cursor/skills/$skill
+curl -fsSL -o ~/.cursor/skills/$skill/SKILL.md \
+  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md"
 ```
 
 **Project-level (shared via your repository):**
 
 ```powershell
 # Windows (PowerShell) -- run from your ABP project root
-New-Item -ItemType Directory -Force ".cursor\skills\abpdev-references" | Out-Null
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" -OutFile ".cursor\skills\abpdev-references\SKILL.md"
+$skill = "abpdev-references"
+New-Item -ItemType Directory -Force ".cursor\skills\$skill" | Out-Null
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" -OutFile ".cursor\skills\$skill\SKILL.md"
 ```
 
 ```bash
 # macOS / Linux
-mkdir -p .cursor/skills/abpdev-references
-curl -fsSL -o .cursor/skills/abpdev-references/SKILL.md \
-  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md"
+skill="abpdev-references"
+mkdir -p .cursor/skills/$skill
+curl -fsSL -o .cursor/skills/$skill/SKILL.md \
+  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md"
 ```
 
 ---
@@ -62,14 +81,16 @@ Claude Code reads `CLAUDE.md` files from the project root or `~/.claude/CLAUDE.m
 **Project-level (run from your ABP project root):**
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" >> CLAUDE.md
+skill="abpdev-references"
+curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" >> CLAUDE.md
 ```
 
 **Personal (all projects):**
 
 ```bash
 mkdir -p ~/.claude
-curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" >> ~/.claude/CLAUDE.md
+skill="abpdev-references"
+curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" >> ~/.claude/CLAUDE.md
 ```
 
 > If you have multiple skills, separate them with `---` or a heading.
@@ -82,15 +103,17 @@ Copilot reads instructions from `.github/instructions/*.instructions.md` in your
 
 ```powershell
 # Windows (PowerShell) -- run from your ABP project root
+$skill = "abpdev-references"
 New-Item -ItemType Directory -Force ".github\instructions" | Out-Null
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" -OutFile ".github\instructions\abpdev-references.instructions.md"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" -OutFile ".github\instructions\$skill.instructions.md"
 ```
 
 ```bash
 # macOS / Linux
+skill="abpdev-references"
 mkdir -p .github/instructions
-curl -fsSL -o .github/instructions/abpdev-references.instructions.md \
-  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md"
+curl -fsSL -o .github/instructions/$skill.instructions.md \
+  "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md"
 ```
 
 ---
@@ -102,7 +125,8 @@ OpenCode reads `AGENTS.md` files from the project root.
 **Project-level (run from your ABP project root):**
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md" >> AGENTS.md
+skill="abpdev-references"
+curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/$skill/SKILL.md" >> AGENTS.md
 ```
 
 ---
@@ -113,7 +137,7 @@ For any other AI agent (Windsurf, Cline, Aider, etc.) that supports custom instr
 
 1. Download the skill content:
    ```bash
-   curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/abpdev-references/SKILL.md"
+    curl -fsSL "https://raw.githubusercontent.com/enisn/AbpDevTools/master/skills/<skill-name>/SKILL.md"
    ```
 2. Paste it into your agent's rules file, custom instructions, or system prompt configuration.
 
@@ -153,7 +177,12 @@ Pre-built agent skills with detailed instructions for each `abpdev` command are 
 
 | Skill name | When to fetch |
 |------------|---------------|
-| `abpdev-references` | User asks about switching between NuGet packages and local project references, configuring `local-sources.yml`, or using `abpdev references` commands. |
+| `abpdev-add-package` | User asks about installing a NuGet package into an ABP project and automatically adding module dependencies with `abpdev add-package`. |
+| `abpdev-workflow` | User asks about building, migrating, running, testing, preparing, bundling, or opening logs with AbpDevTools. |
+| `abpdev-environments` | User asks about virtual environments, `abpdev env`, `envapp`, Docker-backed infra tools, or switching shells with environment variables. |
+| `abpdev-migrations` | User asks about EF Core migrations, recreating migrations, or dropping databases across multiple projects. |
+| `abpdev-maintenance` | User asks about cleanup, replacements, tool-path config, updates, notifications, occupied ports, file finding, or ABP Studio version switching. |
+| `abpdev-references` | User asks about switching between NuGet packages and local project references, configuring `local-sources.yml`, using `abpdev references` commands, or the `abpdev local-sources` alias. |
 
 When the user asks about an `abpdev` command covered by a skill, fetch and read that skill
 before responding. Use the raw GitHub URL pattern above.
@@ -167,7 +196,7 @@ before responding. Use the raw GitHub URL pattern above.
 
 ```powershell
 # Windows (PowerShell)
-$skills = @("abpdev-references")
+$skills = @("abpdev-add-package", "abpdev-workflow", "abpdev-environments", "abpdev-migrations", "abpdev-maintenance", "abpdev-references")
 foreach ($skill in $skills) {
     New-Item -ItemType Directory -Force "$env:USERPROFILE\.cursor\skills\$skill" | Out-Null
     Invoke-WebRequest -Uri "https://raw.githubusercontent.com/enisn/AbpDevTools/main/skills/$skill/SKILL.md" -OutFile "$env:USERPROFILE\.cursor\skills\$skill\SKILL.md"
@@ -176,7 +205,7 @@ foreach ($skill in $skills) {
 
 ```bash
 # macOS / Linux
-for skill in abpdev-references; do
+for skill in abpdev-add-package abpdev-workflow abpdev-environments abpdev-migrations abpdev-maintenance abpdev-references; do
     mkdir -p ~/.cursor/skills/$skill
     curl -fsSL -o ~/.cursor/skills/$skill/SKILL.md \
       "https://raw.githubusercontent.com/enisn/AbpDevTools/main/skills/$skill/SKILL.md"

--- a/skills/abpdev-add-package/SKILL.md
+++ b/skills/abpdev-add-package/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: abpdev-add-package
+description: >-
+  Add NuGet packages with abpdev and automatically wire ABP module dependencies.
+  Use when the user wants to install a package from any NuGet source, target one
+  or many projects, control restore/version behavior, or troubleshoot DependsOn
+  updates.
+---
+
+# abpdev add-package
+
+Use `abpdev add-package` when a user wants ABP-aware package installation without the limitations of `abp add-package`.
+
+## When to use
+
+- Add a package from any NuGet source configured in `nuget.config`
+- Add a package to one project or many projects
+- Automatically add `[DependsOn(typeof(...))]` to the project's ABP module
+- Troubleshoot package install or dependency-wiring failures
+
+## Prerequisites
+
+Install AbpDevTools as a global dotnet tool:
+
+```bash
+dotnet tool update -g AbpDevTools
+```
+
+## Command
+
+```bash
+abpdev add-package <package-name> [options]
+```
+
+## Main options
+
+| Option | Meaning |
+|---|---|
+| `-p`, `--project` | Target a specific `.csproj` |
+| `-v`, `--version` | Install a specific version |
+| `--prerelease` | Allow prerelease versions |
+| `-s`, `--skip-dependency` | Skip adding `DependsOn` |
+| `--no-restore` | Skip restore after adding the package |
+| `-a`, `--all` | Add to all discovered projects |
+
+## Typical usage
+
+```bash
+abpdev add-package Volo.Abp.Autofac
+abpdev add-package My.Company.Package -v 1.2.3
+abpdev add-package My.Company.Package --prerelease
+abpdev add-package My.Company.Package -p C:\src\MyApp\src\MyApp.HttpApi.Host\MyApp.HttpApi.Host.csproj
+abpdev add-package Some.NonAbp.Package --skip-dependency
+abpdev add-package My.Shared.Package --all
+```
+
+## What the command does
+
+1. Runs `dotnet add package`, so normal NuGet sources are respected.
+2. Restores packages unless `--no-restore` is passed.
+3. Reads the installed package metadata to find the ABP module type.
+4. Parses the consumer project source to find its ABP module class.
+5. Adds the needed `[DependsOn(typeof(...))]` entry if applicable.
+
+## Guidance for agents
+
+- Prefer this command over `abp add-package` when the package may come from a custom/private feed.
+- Use `--skip-dependency` for non-ABP packages or when the user only wants the package reference.
+- Use `-p` when the repo contains multiple app/module projects and the target is known.
+- Use `-a` only when the user explicitly wants every matching project updated.
+- This command is designed to be safe to re-run and should avoid duplicate dependency attributes.
+
+## Troubleshooting
+
+**Package installed but no `DependsOn` change appeared**
+- The package may not expose an ABP module class.
+- The target project may not contain an ABP module class.
+- Re-run with `--skip-dependency` if the package is not meant to be an ABP module.
+
+**Package cannot be found**
+- Check the configured NuGet sources in `nuget.config`.
+- If a prerelease version is needed, add `--prerelease`.
+
+**Wrong project was updated**
+- Re-run with `-p <path-to-csproj>`.
+
+**Restore is too slow or should be handled separately**
+- Use `--no-restore`, then run `dotnet restore` later.

--- a/skills/abpdev-environments/SKILL.md
+++ b/skills/abpdev-environments/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: abpdev-environments
+description: >-
+  Manage AbpDevTools virtual environments and environment apps with abpdev. Use
+  when the user wants to configure connection-string environments, start/stop
+  Docker-backed infra tools, or open a shell with a selected environment.
+---
+
+# abpdev environments
+
+Use this skill for `env`, `envapp`, and process environment switching.
+
+## Covered commands
+
+| Command | Purpose |
+|---|---|
+| `abpdev env` | Explain virtual environment usage |
+| `abpdev env config` | Open environment configuration |
+| `abpdev envapp` | Show environment app help/context |
+| `abpdev envapp config` | Open environment-app command configuration |
+| `abpdev envapp start` | Start infra tools such as SQL Server, Redis, RabbitMQ |
+| `abpdev envapp stop` | Stop one or all configured infra tools |
+| `abpdev switch-to-env` | Open a terminal with a selected environment applied |
+| `abpdev run --env <name>` | Run apps with a virtual environment |
+
+## Config file locations
+
+Global configs are under:
+
+```text
+%AppData%\abpdev
+```
+
+Main files in this area:
+
+- `EnvironmentConfiguration.yml` via `abpdev env config`
+- `environment-tools.yml` via `abpdev envapp config`
+- `tools-configuration.yml` for terminal/open command overrides
+
+## Virtual environments
+
+`abpdev env config` manages named sets of environment variables, mainly for connection strings.
+
+Default environment names include:
+
+- `SqlServer`
+- `MongoDb`
+- `PostgreSql`
+- `MySql`
+
+Example shape:
+
+```yaml
+SqlServer:
+  variables:
+    ConnectionStrings__Default: Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;TrustServerCertificate=True
+
+MongoDb:
+  variables:
+    ConnectionStrings__Default: mongodb://localhost:27017/{AppName}_{Today}
+```
+
+Tokens like `{AppName}` and `{Today}` are intended for templated environment values.
+
+## Using an environment
+
+Apply it directly while running:
+
+```bash
+abpdev run --env SqlServer
+abpdev run --env PostgreSql -p MyApp.HttpApi.Host
+```
+
+Or open a new terminal with that environment applied:
+
+```bash
+abpdev switch-to-env SqlServer
+```
+
+On Windows this uses the configured terminal command, which defaults to `wt`.
+
+## Environment apps
+
+`abpdev envapp start` and `abpdev envapp stop` manage external infrastructure, usually through Docker commands stored in config.
+
+Default app keys include:
+
+- `sqlserver`
+- `sqlserver-edge`
+- `postgresql`
+- `mysql`
+- `mongodb`
+- `redis`
+- `rabbitmq`
+
+Examples:
+
+```bash
+abpdev envapp start sqlserver
+abpdev envapp start redis rabbitmq
+abpdev envapp start sqlserver -p MyStrongPassword123! -v
+abpdev envapp stop sqlserver
+abpdev envapp stop all
+```
+
+Notes:
+
+- `envapp start` can take multiple app names.
+- `-p`, `--password` replaces the placeholder `Passw0rd` inside configured start commands.
+- `-v`, `--verbose` shows Docker command output.
+- `envapp stop` currently expects Docker-based stop commands.
+
+## Configuration format
+
+`abpdev envapp config` opens a YAML dictionary keyed by app name.
+
+Preferred schema:
+
+```yaml
+sqlserver:
+  start-cmds:
+    - docker start tmp-sqlserver
+    - docker run --name tmp-sqlserver --restart unless-stopped -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Passw0rd" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-CU8-ubuntu
+  stop-cmds:
+    - docker kill tmp-sqlserver
+    - docker rm tmp-sqlserver
+```
+
+Legacy single-string keys are still supported, but arrays are preferred.
+
+## Guidance for agents
+
+- Use `abpdev run --env <name>` when the user wants an environment only for that run.
+- Use `abpdev switch-to-env <name>` when the user explicitly wants a shell/session switched.
+- Use `abpdev envapp start` only for the infra tools the project actually needs.
+- If the user is onboarding a project, `abpdev prepare` may be a better entry point because it can infer and start required env apps automatically.
+
+## Troubleshooting
+
+**App name is not recognized**
+- Run `abpdev envapp config` and verify the key name.
+
+**Wrong terminal opens for `switch-to-env`**
+- Check `abpdev tools config` and update the `terminal` tool path.
+
+**Docker command needs customization**
+- Edit `environment-tools.yml` via `abpdev envapp config`.

--- a/skills/abpdev-maintenance/SKILL.md
+++ b/skills/abpdev-maintenance/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: abpdev-maintenance
+description: >-
+  Use AbpDevTools maintenance and utility commands such as clean, replace,
+  tools/config, notifications, update, find-file, find-port, and ABP Studio
+  switching. Use when the user wants repo cleanup, config-driven text
+  replacement, process/port inspection, tool updates, or local tool-path setup.
+---
+
+# abpdev maintenance
+
+Use this skill for utility and maintenance commands outside the main run/migration/reference flows.
+
+## Covered commands
+
+| Command | Purpose |
+|---|---|
+| `abpdev clean` | Delete `bin`, `obj`, `node_modules`, or configured folders recursively |
+| `abpdev clean config` | Open clean configuration |
+| `abpdev replace` | Run configured text replacements |
+| `abpdev replace config` | Open replacement configuration |
+| `abpdev logs clear` | Delete `logs.txt` for one or many projects |
+| `abpdev tools` | Show configured external tool paths |
+| `abpdev tools config` | Open tool path configuration |
+| `abpdev enable-notifications` | Enable desktop notifications |
+| `abpdev disable-notifications` | Disable desktop notifications |
+| `abpdev update` | Check for AbpDevTools updates |
+| `abpdev update --apply` | Self-update AbpDevTools |
+| `abpdev find-file` | Search descendant or ascendant file paths by text |
+| `abpdev find-port` | Find or kill processes using a port |
+| `abpdev abp-studio switch` | Switch ABP Studio version/channel |
+
+## Global config location
+
+```text
+%AppData%\abpdev
+```
+
+Useful files:
+
+- `clean-configuration.yml`
+- `replacements.yml`
+- `tools-configuration.yml`
+- `notifications.yml`
+
+## clean
+
+```bash
+abpdev clean [working-directory]
+abpdev clean -s
+abpdev clean -i node_modules
+```
+
+Useful options:
+
+- `-s`, `--soft-delete`: send folders to recycle bin instead of hard delete
+- `-i`, `--ignore-path`: skip matching paths
+
+Default folders come from `clean-configuration.yml` and include:
+
+- `bin`
+- `obj`
+- `node_modules`
+
+## replace
+
+```bash
+abpdev replace <rule-name> -p <working-directory>
+abpdev replace all -p <working-directory>
+abpdev replace -i
+abpdev replace ConnectionStrings -f appsettings.json
+```
+
+Useful options:
+
+- `-p`, `--path`: working directory
+- `-i`, `--interactive`: prompt for rule and/or file selection
+- `-f`, `--files`: restrict matching files by partial name
+
+Replacement rules are stored in `replacements.yml`.
+
+Example shape:
+
+```yaml
+ConnectionStrings:
+  file-pattern: appsettings.json
+  find: Trusted_Connection=True;
+  replace: User ID=SA;Password=12345678Aa;
+```
+
+## tools
+
+```bash
+abpdev tools
+abpdev tools config
+```
+
+This config stores executable names/paths such as:
+
+- `dotnet`
+- `abp`
+- `powershell`
+- `open`
+- `terminal`
+
+Use `abpdev tools config` if the user's shell, terminal, or ABP CLI binary lives in a non-default location.
+
+## logs clear
+
+```bash
+abpdev logs clear -p MyApp.HttpApi.Host
+abpdev logs clear -p all --force
+abpdev logs clear -i
+```
+
+Useful options:
+
+- `-p`, `--project`: select a project name, or `all`
+- `-i`, `--interactive`: choose interactively
+- `-f`, `--force`: delete without confirmation
+
+Behavior:
+
+- Finds runnable projects in the working directory
+- Deletes `<project>/Logs/logs.txt` when present
+- Can clear logs for every discovered project with `-p all`
+
+## notifications
+
+```bash
+abpdev enable-notifications
+abpdev disable-notifications
+abpdev disable-notifications --uninstall
+```
+
+Notes:
+
+- Supported on Windows and macOS
+- On Windows, enabling notifications installs the `BurntToast` PowerShell module
+- `--uninstall` removes `BurntToast` while disabling notifications
+
+## update
+
+```bash
+abpdev update
+abpdev update --apply
+abpdev update --apply --yes
+```
+
+Notes:
+
+- `abpdev update` checks for a newer version
+- `--apply` launches `dotnet tool update -g AbpDevTools`
+- `--yes` skips the confirmation prompt
+
+## find-file
+
+```bash
+abpdev find-file appsettings.json
+abpdev find-file appsettings.json C:\src\MyApp
+abpdev find-file Directory.Build.props . -a
+```
+
+Notes:
+
+- Default behavior searches descendants
+- `-a`, `--ascendant` searches upward through parent folders instead
+
+## find-port
+
+```bash
+abpdev find-port 44307
+abpdev find-port 44307 --kill
+```
+
+Behavior:
+
+- Shows processes using the port
+- Can interactively inspect details, copy PID/path, open location, refresh, or kill
+- `--kill` skips the menu and kills the found process(es) directly
+
+## ABP Studio switching
+
+```bash
+abpdev abp-studio switch 1.2.3
+abpdev abp-studio switch 1.2.3 -c stable
+abpdev abp-studio switch 1.2.3 -f
+```
+
+Useful options:
+
+- `-c`, `--channel`: release channel, defaults to `stable`
+- `-f`, `--force`: re-download the package
+- `-i`, `--install-dir`: override install directory
+- `-p`, `--packages-dir`: override package cache directory
+
+Behavior:
+
+- Downloads the requested ABP Studio package from `abp.io`
+- Uses `Update.exe apply --package <nupkg>` to switch versions
+
+## Guidance for agents
+
+- Use `clean -s` when the user wants safer cleanup.
+- Use `replace config` before `replace` when the needed replacement rule does not already exist.
+- Use `tools config` before troubleshooting command-not-found issues with `dotnet`, `abp`, or terminal launch behavior.
+- Use `find-port` when a dev port is occupied instead of asking the user to inspect processes manually.

--- a/skills/abpdev-migrations/SKILL.md
+++ b/skills/abpdev-migrations/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: abpdev-migrations
+description: >-
+  Manage EF Core migrations and database drops across multiple ABP projects.
+  Use when the user wants to add, clear, recreate migrations, or drop databases
+  for one or many EntityFrameworkCore projects.
+---
+
+# abpdev migrations
+
+Use this skill for EF Core migration and database-drop workflows.
+
+## Covered commands
+
+| Command | Purpose |
+|---|---|
+| `abpdev migrations add` | Add a migration to one or more EF Core projects |
+| `abpdev migrations clear` | Delete `Migrations` folders |
+| `abpdev migrations recreate` | Clear migrations, recreate an initial migration, optionally drop databases |
+| `abpdev database-drop` | Drop databases for EF Core projects with design-time tools |
+
+## Prerequisites
+
+- AbpDevTools installed
+- `dotnet-ef` available for migration commands
+- Target projects should be discoverable EntityFrameworkCore projects
+
+## Shared options
+
+Migration commands share these selectors:
+
+- `-a`, `--all`: run on all discovered EF Core projects
+- `-p`, `--projects`: filter by project name/path fragment
+- positional `working-directory`: root directory to search
+
+If neither `--all` nor `--projects` is given, the commands use interactive project selection.
+
+## Add migrations
+
+```bash
+abpdev migrations add [working-directory] -n Initial
+abpdev migrations add -a -n AddAuditTables
+abpdev migrations add -p MyApp.EntityFrameworkCore -n AddTenantIndexes
+```
+
+Behavior:
+
+- Runs `dotnet-ef migrations add <name> --project <csproj>` for each selected project
+- Shows live per-project progress/status
+
+## Clear migrations
+
+```bash
+abpdev migrations clear
+abpdev migrations clear -a
+abpdev migrations clear -p MyApp.EntityFrameworkCore
+```
+
+Behavior:
+
+- Deletes the `Migrations` folder next to each selected EF Core project
+
+## Recreate migrations
+
+```bash
+abpdev migrations recreate
+abpdev migrations recreate --drop-database
+abpdev migrations recreate -p MyApp.EntityFrameworkCore --drop-database
+```
+
+Behavior:
+
+1. Deletes each selected project's `Migrations` folder
+2. Runs `dotnet-ef migrations add Initial --project <csproj>`
+3. Optionally runs `dotnet ef database drop --force` in each selected project directory
+
+Notes:
+
+- The recreated migration name is currently `Initial`.
+- `--drop-database` only affects the selected projects.
+
+## Database drop
+
+```bash
+abpdev database-drop
+abpdev database-drop --force
+abpdev database-drop -e SqlServer
+abpdev database-drop -p Volo.Abp.EntityFrameworkCore.SqlServer
+```
+
+Useful options:
+
+- `-f`, `--force`: pass `--force` to EF database drop
+- `-p`, `--package`: only keep projects with a direct reference to a specific package
+- `-e`, `--env`: apply a configured virtual environment before dropping
+
+Behavior:
+
+- Finds EF Core projects with design-time tools
+- Optionally filters them by direct package reference
+- Runs `dotnet ef database drop`
+
+## Guidance for agents
+
+- Use `migrations add` for normal schema evolution.
+- Use `migrations recreate` only when the user explicitly wants a reset-style workflow.
+- Use `database-drop -e <env>` when connection strings should come from a named environment.
+- In multi-provider repos, `database-drop --package <provider-package>` is useful to isolate SQL Server vs PostgreSQL projects.
+
+## Troubleshooting
+
+**No EF Core projects found**
+- Confirm the working directory is the solution root.
+- Confirm the EF Core project has design-time tooling where required.
+
+**Migration creation fails**
+- Ensure `dotnet-ef` is installed and available on `PATH`.
+- Build the solution first if the project has compile errors.
+
+**Wrong project was selected**
+- Re-run with `-p <name-fragment>` or `--all`.

--- a/skills/abpdev-references/SKILL.md
+++ b/skills/abpdev-references/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Switch between NuGet package references and local project references using the
   abpdev CLI. Use when the user wants to configure local-sources.yml, convert
   packages to local project references, convert back to package references, debug
-  ABP source locally, or troubleshoot reference switching in ABP-based projects.
+  ABP source locally, use the local-sources config alias, or troubleshoot
+  reference switching in ABP-based projects.
 ---
 
 # abpdev references
@@ -23,9 +24,12 @@ dotnet tool update -g AbpDevTools
 
 | Command | Purpose |
 |---------|---------|
+| `abpdev local-sources` | Open the same local sources configuration file directly |
 | `abpdev references config` | Create (if missing) and open `local-sources.yml` in your default editor |
 | `abpdev references to-local [dir] [-s sources]` | PackageReference -> ProjectReference |
 | `abpdev references to-package [dir] [-s sources]` | ProjectReference -> PackageReference |
+
+`abpdev local-sources` and `abpdev references config` point to the same global configuration.
 
 - `dir` defaults to the current directory. All `.csproj` files are found recursively.
 - `-s` / `--sources` filters by source key (space-separated). Omit to process all configured sources.
@@ -38,7 +42,7 @@ dotnet tool update -g AbpDevTools
 %AppData%\abpdev\local-sources.yml
 ```
 
-Run `abpdev references config` to create the file with defaults and open it.
+Run `abpdev references config` or `abpdev local-sources` to create the file with defaults and open it.
 
 ### Format
 
@@ -153,6 +157,8 @@ What happens:
 ```bash
 # 1. One-time setup: configure your local source paths
 abpdev references config
+# or
+abpdev local-sources
 # Edit the YAML: set `path` to your local checkout
 
 # 2. Switch to local references for debugging / development
@@ -211,7 +217,7 @@ Source order matters when the same package appears in multiple sources -- first 
 **Package not converted to local:**
 - Verify a `.csproj` whose file name matches the package ID exists under the source `path`.
 - Verify the package name matches at least one entry in `packages`.
-- Run `abpdev references config` and check the `path` value.
+- Run `abpdev references config` or `abpdev local-sources` and check the `path` value.
 
 **Version not restored when switching back:**
 - `to-local` stores one version per source key, not per package. All packages from the same source share that version.

--- a/skills/abpdev-workflow/SKILL.md
+++ b/skills/abpdev-workflow/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: abpdev-workflow
+description: >-
+  Run the core AbpDevTools developer workflow commands: build, run, test,
+  prepare, logs, and bundle. Use when the user wants to build or run ABP
+  solutions, prepare a machine, inspect logs, or handle Blazor WASM bundling.
+---
+
+# abpdev workflow
+
+Use this skill for the day-to-day application workflow commands.
+
+## Covered commands
+
+| Command | Purpose |
+|---|---|
+| `abpdev build` | Recursively build solutions/projects |
+| `abpdev migrate` | Run `.DbMigrator` projects or fallback `--migrate-database` apps |
+| `abpdev run` | Run app projects and optionally migrators |
+| `abpdev test` | Recursively run `dotnet test` |
+| `abpdev prepare` | Prepare the project on a new machine |
+| `abpdev logs` | Open the selected project's `Logs` folder or `logs.txt` |
+| `abpdev bundle` | Run `abp bundle` for Blazor WASM projects |
+| `abpdev bundle list` | List Blazor WASM projects that need bundling |
+
+## Prerequisites
+
+```bash
+dotnet tool update -g AbpDevTools
+```
+
+## build
+
+```bash
+abpdev build [working-directory] [options]
+```
+
+Useful options:
+
+- `-f`, `--build-files`: filter target `.sln`, `.slnx`, or `.csproj` files by name
+- `-i`, `--interactive`: choose targets interactively
+- `-c`, `--configuration`: pass build configuration
+
+Behavior:
+
+- Searches recursively for `.sln` and `.slnx`
+- Falls back to `.csproj` if no solutions exist
+- Uses `dotnet build /graphBuild`
+
+## run
+
+```bash
+abpdev run [working-directory] [options]
+```
+
+Useful options:
+
+- `-a`, `--all`: run all discovered app projects
+- `-p`, `--projects`: filter projects by name/path fragment
+- `-w`, `--watch`: run in watch mode
+- `--skip-migrate`: skip `.DbMigrator` projects
+- `--no-build`: pass `--no-build` to `dotnet run`
+- `-g`, `--graphBuild`: use graph build behavior
+- `-i`, `--install-libs`: run `abp install-libs`
+- `--skip-check-libs`: skip missing `wwwroot/libs` checks
+- `-e`, `--env`: apply a configured virtual environment
+- `-r`, `--retry`: retry when apps exit
+- `-v`, `--verbose`: show verbose project output
+- `--yml`: explicitly point to an `abpdev.yml`
+
+Behavior:
+
+- Loads `abpdev.yml` from the working directory when present
+- Runs migrators first unless skipped
+- Prompts for project selection when multiple runnable apps are found and interactive input is available
+- Can detect missing `wwwroot/libs` and offer to run `abp install-libs`
+
+## migrate
+
+```bash
+abpdev migrate [working-directory] [options]
+```
+
+Useful options:
+
+- `--no-build`: pass `--no-build` to migrator runs
+- `-e`, `--env`: apply a configured virtual environment
+- `-a`, `--all`: run all matching migrators/fallback projects
+- `-p`, `--projects`: filter projects by name/path fragment
+
+Behavior:
+
+- Finds `.DbMigrator` executable projects recursively and runs them
+- If none are found, looks for runnable projects supporting `--migrate-database`
+- Applies local `abpdev.yml` environment settings and optional `--env` overrides
+
+## Local YAML
+
+Project-local run settings live in `abpdev.yml` and can include:
+
+```yaml
+run:
+  watch: false
+  no-build: false
+  graph-build: false
+  configuration: Debug
+  skip-migrate: false
+  skip-check-libs: false
+  projects:
+    - MyApp.HttpApi.Host
+
+environment:
+  name: SqlServer
+```
+
+## test
+
+```bash
+abpdev test [working-directory] [options]
+```
+
+Useful options:
+
+- `-f`, `--files`: filter solutions by name/path fragment
+- `-i`, `--interactive`: select target solutions interactively
+- `-c`, `--configuration`: pass test configuration
+- `--no-build`: pass `--no-build` to `dotnet test`
+
+Behavior:
+
+- Searches `.sln` and `.slnx`
+- Does not fall back to `.csproj` test discovery today
+
+## prepare
+
+```bash
+abpdev prepare [working-directory] [options]
+```
+
+Useful options:
+
+- `--no-config`: do not create `abpdev.yml`
+- `--no-install-libs`: skip `abp install-libs`
+- `--no-env-apps`: skip environment app startup
+- `--no-bundle`: skip Blazor WASM bundling
+
+Behavior:
+
+- Scans runnable projects for infrastructure dependencies
+- Starts needed environment apps unless disabled
+- Creates local `abpdev.yml` files when it can infer an environment
+- Runs `abp install-libs`
+- Bundles Blazor WASM projects unless disabled
+
+## logs
+
+```bash
+abpdev logs <project-name> -p <working-directory>
+abpdev logs -i -p <working-directory>
+abpdev logs <project-name> -n 20
+abpdev logs <project-name> --open
+```
+
+Behavior:
+
+- Finds runnable projects
+- Prints the last 100 lines from `<project>/Logs/logs.txt` by default
+- `-n`, `--lines` controls how many lines are printed
+- `-o`, `--open` opens the log file or folder with the OS default app instead
+
+## bundle
+
+```bash
+abpdev bundle [working-directory] [-g]
+abpdev bundle list [working-directory]
+```
+
+Behavior:
+
+- Detects Blazor WebAssembly projects by SDK name
+- Runs `abp bundle -wd <project-dir>` for each detected WASM project
+- `-g`, `--graphBuild` builds the project first
+
+## Guidance for agents
+
+- Use `abpdev prepare` for onboarding/new-machine setup, not as a default replacement for `run`.
+- Use `abpdev run --yml <path>` when the repo has multiple startup contexts.
+- Use `abpdev bundle list` before `abpdev bundle` if the user only wants discovery.
+- Prefer explicit `--projects` filters in large monorepos to avoid launching unrelated apps.
+
+## Typical workflows
+
+```bash
+# First-time setup on a machine
+abpdev prepare
+
+# Daily development run
+abpdev run -e SqlServer
+
+# Run only database migrations
+abpdev migrate -e SqlServer
+
+# Run a filtered set of apps without migration
+abpdev run --skip-migrate -p AuthServer HttpApi.Host
+
+# Build and test only selected solutions
+abpdev build -f MyApp
+abpdev test -f MyApp --no-build
+```

--- a/src/AbpDevTools/Commands/LogsCommand.cs
+++ b/src/AbpDevTools/Commands/LogsCommand.cs
@@ -1,13 +1,14 @@
-﻿using AbpDevTools.Configuration;
 using AbpDevTools.Services;
 using CliFx.Infrastructure;
 using Spectre.Console;
 
 namespace AbpDevTools.Commands;
 
-[Command("logs")]
+[Command("logs", Description = "Print the last lines of project logs or open them with the operating system default app.")]
 public class LogsCommand : ICommand
 {
+    private const int DefaultTailLineCount = 100;
+
     [CommandParameter(0, Description = "Determines the project to open logs of it.", IsRequired = false)]
     public string? ProjectName { get; set; }
 
@@ -16,6 +17,12 @@ public class LogsCommand : ICommand
 
     [CommandOption("interactive", 'i', Description = "Options will be asked as prompt when this option used.")]
     public bool Interactive { get; set; }
+
+    [CommandOption("open", 'o', Description = "Open the log file or folder with the operating system default app instead of printing log lines.")]
+    public bool OpenWithDefaultApp { get; set; }
+
+    [CommandOption("lines", 'n', Description = "Number of lines to print from the end of logs.txt when not using --open. Default: 100.")]
+    public int Lines { get; set; } = DefaultTailLineCount;
 
     protected readonly RunnableProjectsProvider runnableProjectsProvider;
     protected readonly Platform platform;
@@ -33,19 +40,7 @@ public class LogsCommand : ICommand
             WorkingDirectory = Directory.GetCurrentDirectory();
         }
 
-        var csprojs = await AnsiConsole.Status()
-            .StartAsync("Looking for projects...", async ctx =>
-            {
-                ctx.Spinner(Spinner.Known.SimpleDotsScrolling);
-
-                await Task.Yield();
-
-                var projects = runnableProjectsProvider.GetRunnableProjects(WorkingDirectory);
-
-                AnsiConsole.MarkupLine($"[green]{projects.Length}[/] project files found.");
-
-                return projects;
-            });
+        var csprojs = runnableProjectsProvider.GetRunnableProjects(WorkingDirectory);
 
         if (string.IsNullOrEmpty(ProjectName))
         {
@@ -64,14 +59,22 @@ public class LogsCommand : ICommand
             {
                 await console.Output.WriteLineAsync("You have to pass a project name.\n");
                 await console.Output.WriteLineAsync("\n\tUsage:");
-                await console.Output.WriteLineAsync("\tlogs -p <project-name>");
+                await console.Output.WriteLineAsync("\tabpdev logs <project-name>");
+                await console.Output.WriteLineAsync("\tabpdev logs <project-name> -n 100");
+                await console.Output.WriteLineAsync("\tabpdev logs <project-name> --open");
                 await console.Output.WriteLineAsync("\nAvailable project names:\n\n\t - " +
                     string.Join("\n\t - ", csprojs.Select(x => x.Name.Split(Path.DirectorySeparatorChar).Last())));
                 return;
             }
         }
 
-        var selectedCsproj = csprojs.FirstOrDefault(x => x.FullName.Contains(ProjectName));
+        if (Lines <= 0)
+        {
+            await console.Error.WriteLineAsync("The '--lines' option must be greater than 0.");
+            return;
+        }
+
+        var selectedCsproj = csprojs.FirstOrDefault(x => x.FullName.Contains(ProjectName, StringComparison.InvariantCultureIgnoreCase));
 
         if (selectedCsproj == null)
         {
@@ -81,23 +84,75 @@ public class LogsCommand : ICommand
 
         var dir = Path.GetDirectoryName(selectedCsproj.FullName)!;
         var logsDir = Path.Combine(dir, "Logs");
-        if (Directory.Exists(logsDir))
+        var filePath = Path.Combine(logsDir, "logs.txt");
+
+        if (OpenWithDefaultApp)
         {
-            var filePath = Path.Combine(logsDir, "logs.txt");
-            if (File.Exists(filePath))
+            if (Directory.Exists(logsDir))
             {
-                platform.Open(filePath);
+                if (File.Exists(filePath))
+                {
+                    platform.Open(filePath);
+                }
+                else
+                {
+                    platform.Open(logsDir);
+                }
             }
             else
             {
-                platform.Open(logsDir);
-            }
-        }
-        else
-        {
-            await console.Output.WriteLineAsync("No logs folder found for project.\nOpening project folder...");
+                await console.Output.WriteLineAsync("No logs folder found for project.\nOpening project folder...");
 
-            platform.Open(dir);
+                platform.Open(dir);
+            }
+
+            return;
         }
+
+        if (!Directory.Exists(logsDir))
+        {
+            await console.Output.WriteLineAsync($"No logs folder found for project '{selectedCsproj.Name}'. Use '--open' to inspect the project folder.");
+            return;
+        }
+
+        if (!File.Exists(filePath))
+        {
+            await console.Output.WriteLineAsync($"No logs file found for project '{selectedCsproj.Name}' at '{filePath}'. Use '--open' to inspect the Logs folder.");
+            return;
+        }
+
+        var lastLines = await ReadLastLinesAsync(filePath, Lines);
+
+        if (lastLines.Count == 0)
+        {
+            await console.Output.WriteLineAsync($"Log file is empty: {filePath}");
+            return;
+        }
+
+        await console.Output.WriteLineAsync($"Showing last {lastLines.Count} line(s) from '{filePath}':");
+        foreach (var line in lastLines)
+        {
+            await console.Output.WriteLineAsync(line);
+        }
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadLastLinesAsync(string filePath, int lineCount)
+    {
+        var lines = new Queue<string>(lineCount);
+
+        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(fileStream);
+
+        while (await reader.ReadLineAsync() is { } line)
+        {
+            if (lines.Count == lineCount)
+            {
+                lines.Dequeue();
+            }
+
+            lines.Enqueue(line);
+        }
+
+        return lines.ToArray();
     }
 }

--- a/src/AbpDevTools/Platform.cs
+++ b/src/AbpDevTools/Platform.cs
@@ -6,12 +6,12 @@ namespace AbpDevTools;
 [RegisterTransient]
 public class Platform
 {
-    public void Open(string filePath)
+    public virtual void Open(string filePath)
     {
         OpenProcess(filePath).WaitForExit();
     }
 
-    public Task OpenAsync(string filePath)
+    public virtual Task OpenAsync(string filePath)
     {
         return OpenProcess(filePath).WaitForExitAsync();
     }

--- a/tests/AbpDevTools.Tests/Commands/LogsCommandTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/LogsCommandTests.cs
@@ -1,0 +1,219 @@
+using System.Text;
+using AbpDevTools.Commands;
+using AbpDevTools.Configuration;
+using AbpDevTools.Services;
+using CliFx.Infrastructure;
+using FluentAssertions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using YamlDotNet.Serialization;
+
+namespace AbpDevTools.Tests.Commands;
+
+public class LogsCommandTests : IDisposable
+{
+    private readonly string _testRootPath;
+    private readonly RunnableProjectsProvider _runnableProjectsProvider;
+
+    public LogsCommandTests()
+    {
+        _testRootPath = Path.Combine(Path.GetTempPath(), $"AbpDevTools_LogsCommand_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRootPath);
+
+        _runnableProjectsProvider = new RunnableProjectsProvider(
+            new RunConfiguration(Substitute.For<IDeserializer>(), Substitute.For<ISerializer>()));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testRootPath))
+            {
+                Directory.Delete(_testRootPath, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    [Fact]
+    public void LogsCommand_Defaults_ToTailing100Lines()
+    {
+        var command = CreateCommand();
+
+        command.Lines.ShouldBe(100);
+        command.OpenWithDefaultApp.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrintsLastRequestedLines_ByDefault()
+    {
+        CreateRunnableProjectWithLogs("MyApp.Web", Enumerable.Range(1, 5).Select(i => $"line {i}"));
+
+        var command = CreateCommand();
+        command.WorkingDirectory = _testRootPath;
+        command.ProjectName = "MyApp.Web";
+        command.Lines = 3;
+        var console = new TestConsole();
+
+        await command.ExecuteAsync(console);
+
+        var output = console.GetOutput();
+        output.ShouldContain("Showing last 3 line(s)");
+        output.ShouldContain("line 3");
+        output.ShouldContain("line 4");
+        output.ShouldContain("line 5");
+        output.ShouldNotContain("line 2");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOpenOption_UsesPlatformOpen()
+    {
+        var logFilePath = CreateRunnableProjectWithLogs("MyApp.Web", new[] { "line 1" });
+        var platform = new TestPlatform();
+        var command = CreateCommand(platform);
+        command.WorkingDirectory = _testRootPath;
+        command.ProjectName = "MyApp.Web";
+        command.OpenWithDefaultApp = true;
+        var console = new TestConsole();
+
+        await command.ExecuteAsync(console);
+
+        platform.OpenedPaths.Should().ContainSingle();
+        platform.OpenedPaths[0].ShouldBe(logFilePath);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLogsFileDoesNotExist_WritesHelpfulMessage()
+    {
+        CreateRunnableProject("MyApp.Web");
+
+        var command = CreateCommand();
+        command.WorkingDirectory = _testRootPath;
+        command.ProjectName = "MyApp.Web";
+        var console = new TestConsole();
+
+        await command.ExecuteAsync(console);
+
+        var output = console.GetOutput();
+        output.ShouldContain("No logs folder found for project 'MyApp.Web.csproj'");
+        output.ShouldContain("--open");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInvalidLines_WritesError()
+    {
+        CreateRunnableProjectWithLogs("MyApp.Web", new[] { "line 1" });
+
+        var command = CreateCommand();
+        command.WorkingDirectory = _testRootPath;
+        command.ProjectName = "MyApp.Web";
+        command.Lines = 0;
+        var console = new TestConsole();
+
+        await command.ExecuteAsync(console);
+
+        console.GetError().ShouldContain("'--lines' option must be greater than 0");
+    }
+
+    private LogsCommand CreateCommand(Platform? platform = null)
+    {
+        return new LogsCommand(_runnableProjectsProvider, platform ?? new TestPlatform());
+    }
+
+    private string CreateRunnableProject(string projectName)
+    {
+        var projectDir = Path.Combine(_testRootPath, projectName);
+        Directory.CreateDirectory(projectDir);
+
+        File.WriteAllText(Path.Combine(projectDir, $"{projectName}.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk.Web""><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>");
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), "Console.WriteLine(\"Hello\");");
+
+        return projectDir;
+    }
+
+    private string CreateRunnableProjectWithLogs(string projectName, IEnumerable<string> lines)
+    {
+        var projectDir = CreateRunnableProject(projectName);
+        var logsDir = Path.Combine(projectDir, "Logs");
+        Directory.CreateDirectory(logsDir);
+
+        var logFilePath = Path.Combine(logsDir, "logs.txt");
+        File.WriteAllLines(logFilePath, lines, Encoding.UTF8);
+        return logFilePath;
+    }
+
+    private sealed class TestPlatform : Platform
+    {
+        public List<string> OpenedPaths { get; } = new();
+
+        public override void Open(string filePath)
+        {
+            OpenedPaths.Add(filePath);
+        }
+
+        public override Task OpenAsync(string filePath)
+        {
+            OpenedPaths.Add(filePath);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestConsole : IConsole
+    {
+        private readonly MemoryStream _inputStream = new();
+        private readonly MemoryStream _outputStream = new();
+        private readonly MemoryStream _errorStream = new();
+        private readonly Lazy<ConsoleReader> _input;
+        private readonly Lazy<ConsoleWriter> _output;
+        private readonly Lazy<ConsoleWriter> _error;
+
+        public TestConsole()
+        {
+            _input = new Lazy<ConsoleReader>(() => new ConsoleReader(this, _inputStream, Encoding.UTF8));
+            _output = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _outputStream, Encoding.UTF8));
+            _error = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _errorStream, Encoding.UTF8));
+        }
+
+        public ConsoleReader Input => _input.Value;
+        public ConsoleWriter Output => _output.Value;
+        public ConsoleWriter Error => _error.Value;
+        public bool IsOutputRedirected => true;
+        public bool IsErrorRedirected => true;
+        public bool IsInputRedirected => true;
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+        public int WindowWidth { get; set; } = 120;
+        public int WindowHeight { get; set; } = 30;
+        public int CursorLeft { get; set; }
+        public int CursorTop { get; set; }
+
+        public CancellationToken RegisterCancellationHandler() => CancellationToken.None;
+        public ConsoleKeyInfo ReadKey(bool intercept = false) => default;
+        public void Clear() { }
+        public void ResetColor() { }
+
+        public string GetOutput()
+        {
+            if (_output.IsValueCreated)
+            {
+                _output.Value.Flush();
+            }
+
+            return Encoding.UTF8.GetString(_outputStream.ToArray());
+        }
+
+        public string GetError()
+        {
+            if (_error.IsValueCreated)
+            {
+                _error.Value.Flush();
+            }
+
+            return Encoding.UTF8.GetString(_errorStream.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make bpdev logs print the last 100 lines of logs.txt by default, add --lines/-n for tail size, and keep the old OS-open behavior behind --open/-o
- make logs safer for redirected and LLM-driven execution by removing the spinner-only discovery path and adding tests for tailing, open mode, missing logs, and invalid line counts
- expand the reusable skills/ catalog into grouped command-family skills and document the bpdev local-sources alias inside bpdev-references

## Verification
- dotnet build "AbpDevTools.sln"
- dotnet test "tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj" --no-build

## Notes
- the existing test project still emits pre-existing NuGet warnings about duplicate FluentAssertions references and xUnit version resolution during build/test