### PR TITLE
Fix migration project selection UX

### DIFF
--- a/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
+++ b/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
@@ -27,6 +27,10 @@ public abstract class MigrationsCommandBase : ICommand
         {
             WorkingDirectory = Directory.GetCurrentDirectory();
         }
+        else
+        {
+            WorkingDirectory = Path.GetFullPath(WorkingDirectory);
+        }
 
         return default;
     }
@@ -77,7 +81,8 @@ public abstract class MigrationsCommandBase : ICommand
             return projectFile.Name;
         }
 
-        var relativePath = Path.GetRelativePath(WorkingDirectory!, projectFile.FullName);
+        var fullWorkingDirectory = Path.GetFullPath(WorkingDirectory);
+        var relativePath = Path.GetRelativePath(fullWorkingDirectory, projectFile.FullName);
         return string.IsNullOrWhiteSpace(relativePath) || relativePath == "."
             ? projectFile.Name
             : relativePath;

--- a/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
+++ b/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
@@ -44,9 +44,17 @@ public abstract class MigrationsCommandBase : ICommand
         {
             projectFiles = projectFiles.Where(pf => Projects.Any(a => pf.FullName.Contains(a))).ToArray();
         }
-        else if (!RunAll && projectFiles.Length > 0)
+        else if (!RunAll && projectFiles.Length > 1)
         {
-            var chosenProjects = AnsiConsole.Prompt(new MultiSelectionPrompt<string>()
+            projectFiles = PromptForProjectSelection(projectFiles);
+        }
+
+        return projectFiles;
+    }
+
+    protected virtual FileInfo[] PromptForProjectSelection(FileInfo[] projectFiles)
+    {
+        var chosenProjects = AnsiConsole.Prompt(new MultiSelectionPrompt<FileInfo>()
                 .Title("Choose project to create migrations.")
                 .Required(true)
                 .PageSize(12)
@@ -55,20 +63,29 @@ public abstract class MigrationsCommandBase : ICommand
                 .InstructionsText(
                             "[grey](Press [mediumpurple2]<space>[/] to toggle a project, " +
                             "[green]<enter>[/] to accept)[/]")
-                .AddChoices(projectFiles
-                    .Select(p => Path.GetDirectoryName(p.FullName.Replace(WorkingDirectory, string.Empty)).Trim('\\'))
-                    .ToArray())
+                .UseConverter(GetProjectSelectionLabel)
+                .AddChoices(projectFiles)
             );
 
-            projectFiles = projectFiles.Where(p => chosenProjects.Any(cp => p.FullName.Contains(cp))).ToArray();
-        }
-
-        return projectFiles;
+        return chosenProjects.ToArray();
     }
 
-    async Task<FileInfo[]> GetEfCoreProjectsAsync()
+    protected virtual string GetProjectSelectionLabel(FileInfo projectFile)
+    {
+        if (string.IsNullOrWhiteSpace(WorkingDirectory))
+        {
+            return projectFile.Name;
+        }
+
+        var relativePath = Path.GetRelativePath(WorkingDirectory!, projectFile.FullName);
+        return string.IsNullOrWhiteSpace(relativePath) || relativePath == "."
+            ? projectFile.Name
+            : relativePath;
+    }
+
+    protected virtual Task<FileInfo[]> GetEfCoreProjectsAsync()
     {
         // Pass Projects filter to provider for early filtering to improve performance
-        return await entityFrameworkCoreProjectsProvider.GetEfCoreProjectsAsync(WorkingDirectory!, Projects.Length > 0 ? Projects : null);
+        return entityFrameworkCoreProjectsProvider.GetEfCoreProjectsAsync(WorkingDirectory!, Projects.Length > 0 ? Projects : null);
     }
 }

--- a/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
+++ b/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
@@ -81,6 +81,7 @@ public abstract class MigrationsCommandBase : ICommand
             return projectFile.Name;
         }
 
+        // Normalize defensively: callers may bypass ExecuteAsync (e.g. unit tests).
         var fullWorkingDirectory = Path.GetFullPath(WorkingDirectory);
         var relativePath = Path.GetRelativePath(fullWorkingDirectory, projectFile.FullName);
         return string.IsNullOrWhiteSpace(relativePath) || relativePath == "."

--- a/tests/AbpDevTools.Tests/Commands/Migrations/MigrationsCommandBaseTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/Migrations/MigrationsCommandBaseTests.cs
@@ -70,6 +70,24 @@ public class MigrationsCommandBaseTests
         label.Should().Be(Path.Combine("src", "MyApp.EntityFrameworkCore", "MyApp.EntityFrameworkCore.csproj"));
     }
 
+    [Fact]
+    public void GetProjectSelectionLabel_WithRelativeWorkingDirectory_ReturnsRelativeProjectPath()
+    {
+        // Arrange: use the actual current directory so "." resolves to a real full path
+        var absoluteWorkingDirectory = Directory.GetCurrentDirectory();
+        var project = new FileInfo(Path.Combine(absoluteWorkingDirectory, "src", "MyApp.EntityFrameworkCore", "MyApp.EntityFrameworkCore.csproj"));
+
+        // Supply WorkingDirectory as "." (a relative path) — GetFullPath(".")  == absoluteWorkingDirectory
+        var command = new TestMigrationsCommand(Array.Empty<FileInfo>())
+        {
+            WorkingDirectory = "."
+        };
+
+        var label = command.InvokeGetProjectSelectionLabel(project);
+
+        label.Should().Be(Path.Combine("src", "MyApp.EntityFrameworkCore", "MyApp.EntityFrameworkCore.csproj"));
+    }
+
     [CliFx.Attributes.Command("test-migrations-command")]
     private sealed class TestMigrationsCommand : MigrationsCommandBase
     {

--- a/tests/AbpDevTools.Tests/Commands/Migrations/MigrationsCommandBaseTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/Migrations/MigrationsCommandBaseTests.cs
@@ -1,0 +1,114 @@
+using AbpDevTools.Commands.Migrations;
+using CliFx.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace AbpDevTools.Tests.Commands.Migrations;
+
+public class MigrationsCommandBaseTests
+{
+    [Fact]
+    public async Task ChooseProjectsAsync_WithSingleProject_SkipsPrompt()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var project = new FileInfo(Path.Combine(workingDirectory, "MyApp.EntityFrameworkCore.csproj"));
+        var command = new TestMigrationsCommand(new[] { project })
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        var selectedProjects = await command.InvokeChooseProjectsAsync();
+
+        selectedProjects.Should().ContainSingle().Which.FullName.Should().Be(project.FullName);
+        command.PromptCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ChooseProjectsAsync_WithMultipleProjects_UsesPromptSelection()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var firstProject = new FileInfo(Path.Combine(workingDirectory, "First.EntityFrameworkCore.csproj"));
+        var secondProject = new FileInfo(Path.Combine(workingDirectory, "Second.EntityFrameworkCore.csproj"));
+        var command = new TestMigrationsCommand(new[] { firstProject, secondProject }, projects => new[] { projects[1] })
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        var selectedProjects = await command.InvokeChooseProjectsAsync();
+
+        selectedProjects.Should().ContainSingle().Which.FullName.Should().Be(secondProject.FullName);
+        command.PromptCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void GetProjectSelectionLabel_WithProjectInWorkingDirectory_ReturnsProjectFileName()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var project = new FileInfo(Path.Combine(workingDirectory, "MyApp.EntityFrameworkCore.csproj"));
+        var command = new TestMigrationsCommand(Array.Empty<FileInfo>())
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        var label = command.InvokeGetProjectSelectionLabel(project);
+
+        label.Should().Be("MyApp.EntityFrameworkCore.csproj");
+    }
+
+    [Fact]
+    public void GetProjectSelectionLabel_WithNestedProject_ReturnsRelativeProjectPath()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var project = new FileInfo(Path.Combine(workingDirectory, "src", "MyApp.EntityFrameworkCore", "MyApp.EntityFrameworkCore.csproj"));
+        var command = new TestMigrationsCommand(Array.Empty<FileInfo>())
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        var label = command.InvokeGetProjectSelectionLabel(project);
+
+        label.Should().Be(Path.Combine("src", "MyApp.EntityFrameworkCore", "MyApp.EntityFrameworkCore.csproj"));
+    }
+
+    [CliFx.Attributes.Command("test-migrations-command")]
+    private sealed class TestMigrationsCommand : MigrationsCommandBase
+    {
+        private readonly FileInfo[] projectFiles;
+        private readonly Func<FileInfo[], FileInfo[]> promptSelection;
+
+        public TestMigrationsCommand(FileInfo[] projectFiles, Func<FileInfo[], FileInfo[]>? promptSelection = null)
+            : base(null!)
+        {
+            this.projectFiles = projectFiles;
+            this.promptSelection = promptSelection ?? (projects => projects);
+        }
+
+        public int PromptCallCount { get; private set; }
+
+        public Task<FileInfo[]> InvokeChooseProjectsAsync()
+        {
+            return ChooseProjectsAsync();
+        }
+
+        public string InvokeGetProjectSelectionLabel(FileInfo projectFile)
+        {
+            return GetProjectSelectionLabel(projectFile);
+        }
+
+        public override ValueTask ExecuteAsync(IConsole console)
+        {
+            return default;
+        }
+
+        protected override Task<FileInfo[]> GetEfCoreProjectsAsync()
+        {
+            return Task.FromResult(projectFiles);
+        }
+
+        protected override FileInfo[] PromptForProjectSelection(FileInfo[] projectFiles)
+        {
+            PromptCallCount++;
+            return promptSelection(projectFiles);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- skip migration project checkbox prompts when only one EF Core project matches the current selection
- show relative `.csproj` paths in migration prompts so root-level projects never render as blank checkbox labels
- add regression tests for single-option auto-selection and prompt label formatting

## Testing
- dotnet test "tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj" --filter "FullyQualifiedName~MigrationsCommandBaseTests"
- dotnet test "tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj" --filter "FullyQualifiedName~Commands.Migrations"