### PR TITLE
Skip git directories during file discovery

### DIFF
--- a/src/AbpDevTools/FileExplorer.cs
+++ b/src/AbpDevTools/FileExplorer.cs
@@ -3,15 +3,39 @@
 [RegisterTransient]
 public class FileExplorer
 {
+    private static readonly string[] DefaultExcludedFolders = { ".git" };
+
     public IEnumerable<string> FindDescendants(string path, string pattern)
     {
-        return Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories);
+        return FindDescendants(path, pattern, Array.Empty<string>());
     }
 
     public IEnumerable<string> FindDescendants(string path, string pattern, string[] excludeFolders)
     {
+        var excludedFolders = DefaultExcludedFolders
+            .Concat(excludeFolders ?? Array.Empty<string>())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         return Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories)
-            .Where(x => !excludeFolders.Any(x.Contains));
+            .Where(x => !IsInExcludedFolder(path, x, excludedFolders));
+    }
+
+    private static bool IsInExcludedFolder(string rootPath, string filePath, string[] excludedFolders)
+    {
+        var relativePath = Path.GetRelativePath(rootPath, filePath);
+        var directoryPath = Path.GetDirectoryName(relativePath);
+
+        if (string.IsNullOrEmpty(directoryPath))
+        {
+            return false;
+        }
+
+        var directoryNames = directoryPath.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+
+        return directoryNames.Any(directoryName => excludedFolders.Contains(directoryName, StringComparer.OrdinalIgnoreCase));
     }
 
     public IEnumerable<string> FindAscendants(string path, string pattern)

--- a/tests/AbpDevTools.Tests/Services/FileExplorerTests.cs
+++ b/tests/AbpDevTools.Tests/Services/FileExplorerTests.cs
@@ -1,4 +1,4 @@
-using AbpDevTools.Services;
+using AbpDevTools;
 using FluentAssertions;
 using Xunit;
 

--- a/tests/AbpDevTools.Tests/Services/FileExplorerTests.cs
+++ b/tests/AbpDevTools.Tests/Services/FileExplorerTests.cs
@@ -1,0 +1,54 @@
+using AbpDevTools.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AbpDevTools.Tests.Services;
+
+public class FileExplorerTests : IDisposable
+{
+    private readonly string _testRootPath;
+
+    public FileExplorerTests()
+    {
+        _testRootPath = Path.Combine(Path.GetTempPath(), $"FileExplorerTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRootPath);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testRootPath))
+            {
+                Directory.Delete(_testRootPath, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+
+    [Fact]
+    public void FindDescendants_ShouldSkipGitDirectory()
+    {
+        // Arrange
+        var validProjectDirectory = Path.Combine(_testRootPath, "src", "ValidProject");
+        Directory.CreateDirectory(validProjectDirectory);
+        var validProjectPath = Path.Combine(validProjectDirectory, "ValidProject.csproj");
+        File.WriteAllText(validProjectPath, "<Project />");
+
+        var gitLogDirectory = Path.Combine(_testRootPath, ".git", "logs", "refs", "remotes", "origin");
+        Directory.CreateDirectory(gitLogDirectory);
+        File.WriteAllText(Path.Combine(gitLogDirectory, "ValidProject.csproj"), string.Empty);
+
+        var fileExplorer = new FileExplorer();
+
+        // Act
+        var projectFiles = fileExplorer.FindDescendants(_testRootPath, "*.csproj").ToList();
+
+        // Assert
+        projectFiles.Should().ContainSingle();
+        projectFiles[0].Should().Be(validProjectPath);
+    }
+}


### PR DESCRIPTION
## Summary
- Skip `.git` directories during recursive file discovery.
- Prevent `abpdev references to-package` from trying to parse zero-byte Git log files that happen to end with `.csproj`.
- Add a regression test for `.git/logs/refs/remotes/origin/*.csproj` files.

## Verification
- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj`
- `dotnet build AbpDevTools.sln`
