### PR TITLE
Fix Windows self-update launcher

### DIFF
--- a/src/AbpDevTools/Commands/UpdateCheckCommand.cs
+++ b/src/AbpDevTools/Commands/UpdateCheckCommand.cs
@@ -1,3 +1,4 @@
+using AbpDevTools.Configuration;
 using AbpDevTools.Notifications;
 using AbpDevTools.Services;
 using CliFx.Attributes;
@@ -23,11 +24,16 @@ public class UpdateCheckCommand : ICommand
 
     protected readonly UpdateChecker updateChecker;
     protected readonly INotificationManager notificationManager;
+    protected readonly ToolsConfiguration toolsConfiguration;
 
-    public UpdateCheckCommand(UpdateChecker updateChecker, INotificationManager notificationManager)
+    public UpdateCheckCommand(
+        UpdateChecker updateChecker,
+        INotificationManager notificationManager,
+        ToolsConfiguration toolsConfiguration)
     {
         this.updateChecker = updateChecker;
         this.notificationManager = notificationManager;
+        this.toolsConfiguration = toolsConfiguration;
     }
 
     public ValueTask SoftCheckAsync(IConsole console)
@@ -45,8 +51,6 @@ public class UpdateCheckCommand : ICommand
             return;
         }
 
-        var command = "dotnet tool update -g AbpDevTools";
-
         if (Force)
         {
             console.Output.WriteLine($"Checking for updates...");
@@ -61,6 +65,8 @@ public class UpdateCheckCommand : ICommand
 
         if (result.UpdateAvailable)
         {
+            var tools = toolsConfiguration.GetOptions();
+            var command = FormatManualUpdateCommand(tools["dotnet"]);
             var selfUpdateCommand = "abpdev update --apply";
 
             await notificationManager.SendAsync(
@@ -71,7 +77,7 @@ public class UpdateCheckCommand : ICommand
 
             AnsiConsole.Markup($"\n[blue]To update now, run:[/]\n");
             AnsiConsole.Markup($"  [black on green] {selfUpdateCommand} [/]\n");
-            AnsiConsole.Markup($"\n[grey]Or manually:[/] [yellow]{command}[/]");
+            AnsiConsole.Markup($"\n[grey]Or manually:[/] [yellow]{Markup.Escape(command)}[/]");
         }
         else
         {
@@ -127,14 +133,16 @@ public class UpdateCheckCommand : ICommand
         catch (Exception ex)
         {
             AnsiConsole.Markup($"[red]Failed to start update process: {ex.Message}[/]\n");
-            AnsiConsole.Markup($"[yellow]You can manually update by running: dotnet tool update -g AbpDevTools[/]\n");
+            var tools = toolsConfiguration.GetOptions();
+            AnsiConsole.Markup($"[yellow]You can manually update by running: {Markup.Escape(FormatManualUpdateCommand(tools["dotnet"]))}[/]\n");
             Environment.Exit(1);
         }
     }
 
     private async Task SpawnUpdateProcessAsync()
     {
-        var startInfo = CreateUpdateProcessStartInfo(Environment.ProcessId);
+        var tools = toolsConfiguration.GetOptions();
+        var startInfo = CreateUpdateProcessStartInfo(Environment.ProcessId, tools["powershell"], tools["dotnet"]);
         
         var process = Process.Start(startInfo);
 
@@ -146,27 +154,90 @@ public class UpdateCheckCommand : ICommand
         await Task.CompletedTask;
     }
 
-    internal static ProcessStartInfo CreateUpdateProcessStartInfo(int currentProcessId)
+    internal static ProcessStartInfo CreateUpdateProcessStartInfo(int currentProcessId, string powershell, string dotnet)
     {
+        var dotnetPath = ResolveExecutablePath(dotnet);
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return new ProcessStartInfo
+            var startInfo = new ProcessStartInfo
             {
-                FileName = "powershell.exe",
-                Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"Wait-Process -Id {currentProcessId} -ErrorAction SilentlyContinue; dotnet tool update -g AbpDevTools; exit $LASTEXITCODE\"",
+                FileName = ResolveExecutablePath(powershell),
                 UseShellExecute = false,
                 CreateNoWindow = false,
                 WindowStyle = ProcessWindowStyle.Normal,
             };
+
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add($"Wait-Process -Id {currentProcessId} -ErrorAction SilentlyContinue; & {QuotePowerShellLiteral(dotnetPath)} tool update -g AbpDevTools; exit $LASTEXITCODE");
+
+            return startInfo;
         }
 
-        return new ProcessStartInfo
+        var shellStartInfo = new ProcessStartInfo
         {
             FileName = "/bin/sh",
-            Arguments = $"-c \"while kill -0 {currentProcessId} 2>/dev/null; do sleep 1; done; dotnet tool update -g AbpDevTools\"",
             UseShellExecute = false,
             CreateNoWindow = false,
             WindowStyle = ProcessWindowStyle.Normal,
         };
+
+        shellStartInfo.ArgumentList.Add("-c");
+        shellStartInfo.ArgumentList.Add($"while kill -0 {currentProcessId} 2>/dev/null; do sleep 1; done; {QuoteShellLiteral(dotnetPath)} tool update -g AbpDevTools");
+
+        return shellStartInfo;
+    }
+
+    private static string ResolveExecutablePath(string executable)
+    {
+        if (Path.IsPathRooted(executable) || executable.Contains(Path.DirectorySeparatorChar) || executable.Contains(Path.AltDirectorySeparatorChar))
+        {
+            return executable;
+        }
+
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return executable;
+        }
+
+        var extensions = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD").Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            : [string.Empty];
+
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var extension in extensions)
+            {
+                var candidate = Path.Combine(directory, executable.EndsWith(extension, StringComparison.OrdinalIgnoreCase) ? executable : executable + extension);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return executable;
+    }
+
+    private static string FormatManualUpdateCommand(string dotnet)
+    {
+        return $"{QuoteCommandForDisplay(dotnet)} tool update -g AbpDevTools";
+    }
+
+    private static string QuoteCommandForDisplay(string value)
+    {
+        return value.Contains(' ') ? $"\"{value}\"" : value;
+    }
+
+    private static string QuotePowerShellLiteral(string value)
+    {
+        return $"'{value.Replace("'", "''")}'";
+    }
+
+    private static string QuoteShellLiteral(string value)
+    {
+        return $"'{value.Replace("'", "'\\''")}'";
     }
 }

--- a/src/AbpDevTools/Commands/UpdateCheckCommand.cs
+++ b/src/AbpDevTools/Commands/UpdateCheckCommand.cs
@@ -134,25 +134,37 @@ public class UpdateCheckCommand : ICommand
 
     private async Task SpawnUpdateProcessAsync()
     {
-        var startInfo = GetUpdateProcessStartInfo();
+        var startInfo = CreateUpdateProcessStartInfo(Environment.ProcessId);
         
-         var process = Process.Start(startInfo);
+        var process = Process.Start(startInfo);
 
-         if (process is null)
-         {
+        if (process is null)
+        {
             throw new InvalidOperationException("Failed to start the update process.");
-         }
+        }
 
         await Task.CompletedTask;
     }
 
-    private ProcessStartInfo GetUpdateProcessStartInfo()
+    internal static ProcessStartInfo CreateUpdateProcessStartInfo(int currentProcessId)
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"Wait-Process -Id {currentProcessId} -ErrorAction SilentlyContinue; dotnet tool update -g AbpDevTools; exit $LASTEXITCODE\"",
+                UseShellExecute = false,
+                CreateNoWindow = false,
+                WindowStyle = ProcessWindowStyle.Normal,
+            };
+        }
+
         return new ProcessStartInfo
         {
-            FileName = "dotnet",
-            Arguments = $"tool update -g AbpDevTools",
-            UseShellExecute = true,
+            FileName = "/bin/sh",
+            Arguments = $"-c \"while kill -0 {currentProcessId} 2>/dev/null; do sleep 1; done; dotnet tool update -g AbpDevTools\"",
+            UseShellExecute = false,
             CreateNoWindow = false,
             WindowStyle = ProcessWindowStyle.Normal,
         };

--- a/tests/AbpDevTools.Tests/Commands/UpdateCheckCommandTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/UpdateCheckCommandTests.cs
@@ -1,0 +1,40 @@
+using System.Runtime.InteropServices;
+using AbpDevTools.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace AbpDevTools.Tests.Commands;
+
+public class UpdateCheckCommandTests
+{
+    [Fact]
+    public void CreateUpdateProcessStartInfo_Should_Not_Use_Shell_Execute()
+    {
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+
+        startInfo.UseShellExecute.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreateUpdateProcessStartInfo_Should_Wait_For_Current_Process_Before_Update()
+    {
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+
+        startInfo.Arguments.Should().Contain("12345");
+        startInfo.Arguments.Should().Contain("dotnet tool update -g AbpDevTools");
+    }
+
+    [Fact]
+    public void CreateUpdateProcessStartInfo_On_Windows_Should_Start_PowerShell_Directly()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+
+        startInfo.FileName.Should().Be("powershell.exe");
+        startInfo.Arguments.Should().Contain("Wait-Process -Id 12345");
+    }
+}

--- a/tests/AbpDevTools.Tests/Commands/UpdateCheckCommandTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/UpdateCheckCommandTests.cs
@@ -10,7 +10,7 @@ public class UpdateCheckCommandTests
     [Fact]
     public void CreateUpdateProcessStartInfo_Should_Not_Use_Shell_Execute()
     {
-        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345, "custom-pwsh", "custom-dotnet");
 
         startInfo.UseShellExecute.Should().BeFalse();
     }
@@ -18,23 +18,34 @@ public class UpdateCheckCommandTests
     [Fact]
     public void CreateUpdateProcessStartInfo_Should_Wait_For_Current_Process_Before_Update()
     {
-        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345, "custom-pwsh", "custom-dotnet");
+        var arguments = GetArguments(startInfo);
 
-        startInfo.Arguments.Should().Contain("12345");
-        startInfo.Arguments.Should().Contain("dotnet tool update -g AbpDevTools");
+        arguments.Should().Contain("12345");
+        arguments.Should().Contain("custom-dotnet");
+        arguments.Should().Contain("tool update -g AbpDevTools");
     }
 
     [Fact]
-    public void CreateUpdateProcessStartInfo_On_Windows_Should_Start_PowerShell_Directly()
+    public void CreateUpdateProcessStartInfo_On_Windows_Should_Use_Configured_PowerShell()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return;
         }
 
-        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345);
+        var startInfo = UpdateCheckCommand.CreateUpdateProcessStartInfo(12345, "custom-pwsh", "custom-dotnet");
+        var arguments = GetArguments(startInfo);
 
-        startInfo.FileName.Should().Be("powershell.exe");
-        startInfo.Arguments.Should().Contain("Wait-Process -Id 12345");
+        startInfo.FileName.Should().Be("custom-pwsh");
+        arguments.Should().Contain("Wait-Process -Id 12345");
+        arguments.Should().NotContain("ExecutionPolicy");
+    }
+
+    private static string GetArguments(System.Diagnostics.ProcessStartInfo startInfo)
+    {
+        return startInfo.ArgumentList.Count > 0
+            ? string.Join(" ", startInfo.ArgumentList)
+            : startInfo.Arguments;
     }
 }


### PR DESCRIPTION
## Summary

- fix Windows self-update process launch for `abpdev update --apply`
- avoid ShellExecute resolving `dotnet` as a shell folder target
- wait for the current `abpdev` process to exit before running `dotnet tool update -g AbpDevTools`
- add regression coverage for the generated update process info

## Tests

- `dotnet test "tests\\AbpDevTools.Tests\\AbpDevTools.Tests.csproj"`
