### PR TITLE
Use platform-specific environment app passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ abpdev env config
 > {
 >  "SqlServer": {
 >    "Variables": {
->      "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;TrustServerCertificate=True"
+>      "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True"
 >    }
 >  },
 >  "MongoDB": {
@@ -616,10 +616,20 @@ _You can extend the list or change environments of apps by using `abpdev envapp 
 
 ### Example commands
 
+- Start PostgreSQL with the default `postgres` / `postgres` development credentials
+    ```bash
+    abpdev envapp start postgresql
+    ```
+
 - Start SQL Server with custom SA password
     ```bash
     abpdev envapp start sqlserver -p myPassw0rd
     ```
+
+The database defaults are `sa` / `yourStrong(!)Password` for SQL Server,
+`postgres` / `postgres` for PostgreSQL, and `root` / `root` for MySQL.
+MongoDB and Redis use their images' passwordless defaults. Use `-p` or
+`--password` to override the configured password when creating a container.
 
 ## Switch ABP Studio Version
 Switches the locally installed **ABP Studio** to any published version/channel, ensuring directories exist, caching packages for reuse, and invoking the platform-specific updater with live log streaming and desktop notifications.

--- a/docs/en/commands/prepare.md
+++ b/docs/en/commands/prepare.md
@@ -5,12 +5,12 @@ title: Prepare Command
 
 # Prepare Command
 
-The `abpvdev prepare` command prepares your ABP project for first-time running on your machine. It automatically detects project dependencies, starts required environment apps, installs ABP libraries, and creates local configuration files.
+The `abpdev prepare` command prepares your ABP project for first-time running on your machine. It automatically detects project dependencies, starts required environment apps, installs ABP libraries, and creates local configuration files.
 
 ## Usage
 
 ```
-abpvdev prepare <workingdirectory> [options]
+abpdev prepare <workingdirectory> [options]
 ```
 
 ## Parameters
@@ -23,7 +23,7 @@ abpvdev prepare <workingdirectory> [options]
 
 | Option | Shortcut | Description |
 |--------|----------|-------------|
-| `--no-config` | | Do not create local configuration file (abpvdev.yml) |
+| `--no-config` | | Do not create local configuration file (`abpdev.yml`) |
 | `--help` | `-h` | Shows help text |
 
 ## Examples
@@ -31,19 +31,19 @@ abpvdev prepare <workingdirectory> [options]
 ### Prepare Current Directory
 
 ```bash
-abpvdev prepare
+abpdev prepare
 ```
 
 ### Prepare Specific Path
 
 ```bash
-abpvdev prepare C:\Path\To\Projects
+abpdev prepare C:\Path\To\Projects
 ```
 
 ### Prepare Without Configuration
 
 ```bash
-abpvdev prepare --no-config
+abpdev prepare --no-config
 ```
 
 Use this when you don't want to create local configuration files.
@@ -81,11 +81,11 @@ Bundles Blazor WASM projects if detected.
 
 ### 5. Configuration
 
-Creates `abpvdev.yml` files with appropriate environment settings.
+Creates `abpdev.yml` files with appropriate environment settings.
 
 ## Configuration File
 
-After running prepare, you'll have an `abpvdev.yml` file in your project directory. This file contains:
+After running prepare, you'll have an `abpdev.yml` file in your project directory. This file contains:
 - Database connection strings
 - Environment variables
 - Custom settings
@@ -102,7 +102,7 @@ The configuration supports these placeholders:
 Example:
 ```json
 {
-  "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;"
+  "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True"
 }
 ```
 

--- a/docs/en/environment/environment-apps.md
+++ b/docs/en/environment/environment-apps.md
@@ -11,36 +11,39 @@ Environment apps allow you to easily run commonly used infrastructure services l
 
 ### Default Apps
 
-| App Name | Description | Default Port |
-|----------|-------------|---------------|
-| `sqlserver` | SQL Server | 1433 |
-| `sqlserver-edge` | SQL Server Edge | 1433 |
-| `postgresql` | PostgreSQL | 5432 |
-| `mysql` | MySQL | 3306 |
-| `mongodb` | MongoDB | 27017 |
-| `redis` | Redis | 6379 |
-| `rabbitmq` | RabbitMQ | 5672 |
+| App Name | Default Credentials | Default Port |
+|----------|---------------------|--------------|
+| `sqlserver` | `sa` / `yourStrong(!)Password` | 1433 |
+| `sqlserver-edge` | `sa` / `yourStrong(!)Password` | 1433 |
+| `postgresql` | `postgres` / `postgres` | 5432 |
+| `mysql` | `root` / `root` | 3306 |
+| `mongodb` | No authentication | 27017 |
+| `redis` | No authentication | 6379 |
+| `rabbitmq` | `guest` / `guest` | 5672 |
+
+These credentials are intended for local development only. Do not expose
+containers using these defaults to untrusted networks.
 
 ## Commands
 
 ### Start an Environment App
 
 ```bash
-abpvdev envapp start <appname> [options]
+abpdev envapp start <appname> [options]
 ```
 
 ### Stop an Environment App
 
 ```bash
-abpvdev envapp stop <appname> [options]
+abpdev envapp stop <appname> [options]
 ```
 
 ## Options
 
 | Option | Shortcut | Description |
 |--------|----------|-------------|
-| `--password` | `-p` | Custom password (for SQL Server, MySQL) |
-| `--port` | | Custom port |
+| `--password` | `-p` | Override the configured database password |
+| `--verbose` | `-v` | Show detailed Docker command output |
 | `--help` | `-h` | Shows help text |
 
 ## Examples
@@ -48,49 +51,48 @@ abpvdev envapp stop <appname> [options]
 ### Start SQL Server
 
 ```bash
-abpvdev envapp start sqlserver
+abpdev envapp start sqlserver
 ```
 
 ### Start SQL Server with Custom Password
 
 ```bash
-abpvdev envapp start sqlserver -p myPassw0rd
+abpdev envapp start sqlserver -p myPassw0rd
 ```
+
+The password override applies when the container is created. If the named
+container already exists, Docker starts it with its existing credentials.
+Update the matching virtual-environment connection string when using a custom
+password.
 
 ### Start PostgreSQL
 
 ```bash
-abpvdev envapp start postgresql
+abpdev envapp start postgresql
 ```
 
 ### Start MongoDB
 
 ```bash
-abpvdev envapp start mongodb
+abpdev envapp start mongodb
 ```
 
 ### Start Redis
 
 ```bash
-abpvdev envapp start redis
+abpdev envapp start redis
 ```
 
 ### Start RabbitMQ
 
 ```bash
-abpvdev envapp start rabbitmq
-```
-
-### Start on Custom Port
-
-```bash
-abpvdev envapp start sqlserver --port 1434
+abpdev envapp start rabbitmq
 ```
 
 ### Stop an App
 
 ```bash
-abpvdev envapp stop sqlserver
+abpdev envapp stop sqlserver
 ```
 
 ## Configuration
@@ -100,30 +102,26 @@ abpvdev envapp stop sqlserver
 You can customize the Docker commands used to start each app:
 
 ```bash
-abpvdev envapp config
+abpdev envapp config
 ```
 
-This opens the configuration file where you can:
+This opens `%AppData%/abpdev/environment-tools.yml` where you can:
 - Add new environment apps
 - Modify existing app configurations
+- Change the default password used when `-p` is omitted
 - Change Docker commands and images
 
 ### Example Custom Configuration
 
-```json
-{
-  "EnvironmentApps": {
-    "custom-postgres": {
-      "Image": "postgres:15",
-      "Ports": {
-        "5432": "5433"
-      },
-      "Environment": {
-        "POSTGRES_PASSWORD": "mypassword"
-      }
-    }
-  }
-}
+```yaml
+custom-postgres:
+  DefaultPassword: mypassword
+  StartCmds:
+    - docker start custom-postgres
+    - docker run --name custom-postgres --restart unless-stopped -e "POSTGRES_PASSWORD=Passw0rd" -p 5433:5432 -d postgres:15
+  StopCmds:
+    - docker kill custom-postgres
+    - docker rm custom-postgres
 ```
 
 ## Prerequisites
@@ -144,11 +142,8 @@ docker ps
 
 ### Port Already in Use
 
-Specify a different port:
-
-```bash
-abpvdev envapp start sqlserver --port 1434
-```
+Run `abpdev envapp config` and change the host-side port in the configured
+Docker command.
 
 ### Permission Denied
 
@@ -164,7 +159,7 @@ docker logs <container-name>
 
 ## Automatic Starting
 
-Environment apps can be automatically started when using `abpvdev prepare`:
+Environment apps can be automatically started when using `abpdev prepare`:
 
 The prepare command detects your project's dependencies and automatically starts the required environment apps.
 
@@ -173,19 +168,19 @@ The prepare command detects your project's dependencies and automatically starts
 ### SQL Server
 
 ```
-Server=localhost;Database={AppName};User ID=SA;Password=yourpassword;TrustServerCertificate=True
+Server=localhost;Database={AppName};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True
 ```
 
 ### PostgreSQL
 
 ```
-Host=localhost;Database={AppName};Username=postgres;Password=yourpassword
+Server=localhost;Port=5432;Database={AppName};User Id=postgres;Password=postgres;
 ```
 
 ### MySQL
 
 ```
-Server=localhost;Database={AppName};User ID=root;Password=yourpassword
+Server=localhost;Port=3306;Database={AppName};User Id=root;Password=root;
 ```
 
 ### MongoDB

--- a/docs/en/environment/virtual-environments.md
+++ b/docs/en/environment/virtual-environments.md
@@ -20,7 +20,7 @@ Virtual environments solve the problem of managing different configurations for:
 ### Using the Command
 
 ```bash
-abpvdev env config
+abpdev env config
 ```
 
 This opens an interactive configuration tool where you can:
@@ -31,14 +31,15 @@ This opens an interactive configuration tool where you can:
 
 ## Configuration File
 
-The virtual environments are stored in your `abpvdev.yml` file:
+The global virtual environments are stored in
+`%AppData%/abpdev/EnvironmentConfiguration.yml` on Windows:
 
 ```json
 {
   "Environments": {
     "SqlServer": {
       "Variables": {
-        "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;TrustServerCertificate=True"
+        "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True"
       }
     },
     "MongoDB": {
@@ -70,7 +71,7 @@ This allows running multiple instances with separate databases each day.
 ### Run with Environment
 
 ```bash
-abpvdev run -e SqlServer
+abpdev run -e SqlServer
 ```
 
 Uses the SqlServer environment configuration.
@@ -78,7 +79,7 @@ Uses the SqlServer environment configuration.
 ### Build with Environment
 
 ```bash
-abpvdev build -e SqlServer
+abpdev build -e SqlServer
 ```
 
 ### Add Custom Variables
@@ -105,10 +106,10 @@ Run the same solution with different databases:
 
 ```bash
 # Run with SQL Server
-abpvdev run -e SqlServer
+abpdev run -e SqlServer
 
 # Run with MongoDB
-abpvdev run -e MongoDB
+abpdev run -e MongoDB
 ```
 
 ### Development vs Production
@@ -134,7 +135,8 @@ abpvdev run -e MongoDB
 
 ### Environment Not Found
 
-Make sure the environment is defined in your `abpvdev.yml` file.
+Make sure the environment is defined in the global environment configuration
+opened by `abpdev env config`, or in the project's `abpdev.yml` file.
 
 ### Variables Not Applied
 

--- a/skills/abpdev-environments/SKILL.md
+++ b/skills/abpdev-environments/SKILL.md
@@ -53,7 +53,7 @@ Example shape:
 ```yaml
 SqlServer:
   variables:
-    ConnectionStrings__Default: Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;TrustServerCertificate=True
+    ConnectionStrings__Default: Server=localhost;Database={AppName}_{Today};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True
 
 MongoDb:
   variables:
@@ -106,7 +106,9 @@ abpdev envapp stop all
 Notes:
 
 - `envapp start` can take multiple app names.
-- `-p`, `--password` replaces the placeholder `Passw0rd` inside configured start commands.
+- Default development credentials are `sa` / `yourStrong(!)Password` for SQL Server, `postgres` / `postgres` for PostgreSQL, and `root` / `root` for MySQL.
+- MongoDB and Redis keep the official images' passwordless defaults; RabbitMQ keeps `guest` / `guest`.
+- `-p`, `--password` overrides the configured default and replaces the placeholder `Passw0rd` inside start commands.
 - `-v`, `--verbose` shows Docker command output.
 - `envapp stop` currently expects Docker-based stop commands.
 
@@ -118,9 +120,10 @@ Preferred schema:
 
 ```yaml
 sqlserver:
+  DefaultPassword: yourStrong(!)Password
   start-cmds:
     - docker start tmp-sqlserver
-    - docker run --name tmp-sqlserver --restart unless-stopped -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Passw0rd" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-CU8-ubuntu
+    - docker run --name tmp-sqlserver --restart unless-stopped -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Passw0rd" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-CU8-ubuntu
   stop-cmds:
     - docker kill tmp-sqlserver
     - docker rm tmp-sqlserver

--- a/src/AbpDevTools/Commands/EnvironmentAppStartCommand.cs
+++ b/src/AbpDevTools/Commands/EnvironmentAppStartCommand.cs
@@ -12,8 +12,8 @@ public class EnvironmentAppStartCommand : ICommand
     [CommandParameter(0, IsRequired = false, Description = "Name of the app.")]
     public string[] AppNames { get; set; } = Array.Empty<string>();
 
-    [CommandOption("password", 'p', Description = "Default password for sql images when applicable. Default: 12345678Aa")]
-    public string DefaultPassword { get; set; } = "12345678Aa";
+    [CommandOption("password", 'p', Description = "Overrides the configured default password for database images when applicable.")]
+    public string? DefaultPassword { get; set; }
 
     [CommandOption("verbose", 'v', Description = "Show detailed output from Docker commands.")]
     public bool Verbose { get; set; }
@@ -58,12 +58,20 @@ public class EnvironmentAppStartCommand : ICommand
             throw new CommandException($"ToolName '{appName}' couldn't be recognized. Try one of them: \n - " + string.Join("\n - ", configurations.Keys));
         }
 
-        if (string.IsNullOrEmpty(DefaultPassword))
+        var password = string.IsNullOrEmpty(DefaultPassword)
+            ? option.DefaultPassword
+            : DefaultPassword;
+
+        if (option.StartCmds.Any(cmd => cmd.Contains("Passw0rd", StringComparison.Ordinal)) &&
+            string.IsNullOrEmpty(password))
         {
-            DefaultPassword = "12345678Aa";
+            throw new CommandException(
+                $"No default password is configured for '{appName}'. Specify one with --password or -p.");
         }
 
-        var commands = option.StartCmds.Select(cmd => cmd.Replace("Passw0rd", DefaultPassword)).ToArray();
+        var commands = option.StartCmds
+            .Select(cmd => cmd.Replace("Passw0rd", password ?? string.Empty, StringComparison.Ordinal))
+            .ToArray();
         await RunCommandsAsync(appName,commands, useOrLogic: true);
     }
 

--- a/src/AbpDevTools/Configuration/EnvironmentAppConfiguration.cs
+++ b/src/AbpDevTools/Configuration/EnvironmentAppConfiguration.cs
@@ -13,11 +13,40 @@ public class EnvironmentAppConfiguration : DictionaryConfigurationBase<Environme
     public const string Redis = "redis";
     public const string RabbitMq = "rabbitmq";
 
+    public const string SqlServerDefaultPassword = "yourStrong(!)Password";
+    public const string PostgreSqlDefaultPassword = "postgres";
+    public const string MySqlDefaultPassword = "root";
+
     public EnvironmentAppConfiguration(IDeserializer yamlDeserializer, ISerializer yamlSerializer) : base(yamlDeserializer, yamlSerializer)
     {
     }
 
     public override string FileName => "environment-tools";
+
+    public override Dictionary<string, EnvironmentToolOption> GetOptions()
+    {
+        var options = base.GetOptions();
+        var defaults = GetDefaults();
+        var shouldWrite = false;
+
+        foreach (var defaultOption in defaults)
+        {
+            if (options.TryGetValue(defaultOption.Key, out var option) &&
+                option.DefaultPassword is null &&
+                defaultOption.Value.DefaultPassword is not null)
+            {
+                option.DefaultPassword = defaultOption.Value.DefaultPassword;
+                shouldWrite = true;
+            }
+        }
+
+        if (shouldWrite)
+        {
+            SaveOptions(options);
+        }
+
+        return options;
+    }
 
     protected override Dictionary<string, EnvironmentToolOption> GetDefaults()
     {
@@ -27,30 +56,34 @@ public class EnvironmentAppConfiguration : DictionaryConfigurationBase<Environme
                 new[] 
                 { 
                     "docker start tmp-sqlserver", 
-                    "docker run --name tmp-sqlserver --restart unless-stopped -e \"ACCEPT_EULA=Y\" -e \"SA_PASSWORD=Passw0rd\" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-CU8-ubuntu" 
+                    "docker run --name tmp-sqlserver --restart unless-stopped -e \"ACCEPT_EULA=Y\" -e \"MSSQL_SA_PASSWORD=Passw0rd\" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
                 }, 
-                new[] { "docker kill tmp-sqlserver", "docker rm tmp-sqlserver" }) },
+                new[] { "docker kill tmp-sqlserver", "docker rm tmp-sqlserver" },
+                SqlServerDefaultPassword) },
             { SqlServerEdge, new EnvironmentToolOption(
                 new[] 
                 { 
                     "docker start tmp-sqlserver-edge", 
                     "docker run --name tmp-sqlserver-edge --restart unless-stopped -d --cap-add SYS_PTRACE -e \"ACCEPT_EULA=1\" -e \"MSSQL_SA_PASSWORD=Passw0rd\" -p 1433:1433 mcr.microsoft.com/azure-sql-edge" 
                 }, 
-                new[] { "docker kill tmp-sqlserver-edge", "docker rm tmp-sqlserver-edge" }) },
+                new[] { "docker kill tmp-sqlserver-edge", "docker rm tmp-sqlserver-edge" },
+                SqlServerDefaultPassword) },
             { PostgreSql, new EnvironmentToolOption(
                 new[] 
                 { 
                     "docker start tmp-postgres", 
-                    "docker run --name tmp-postgres --restart unless-stopped -e POSTGRES_PASSWORD=Passw0rd -p 5432:5432 -d postgres" 
+                    "docker run --name tmp-postgres --restart unless-stopped -e \"POSTGRES_PASSWORD=Passw0rd\" -p 5432:5432 -d postgres"
                 }, 
-                new[] { "docker kill tmp-posgres", "docker rm tmp-posgres" }) },
+                new[] { "docker kill tmp-postgres", "docker rm tmp-postgres" },
+                PostgreSqlDefaultPassword) },
             { MySql, new EnvironmentToolOption(
                 new[] 
                 { 
                     "docker start tmp-mysql", 
                     "docker run --name tmp-mysql --restart unless-stopped -e \"MYSQL_ROOT_PASSWORD=Passw0rd\" -p 3306:3306 --platform linux/x86_64 -d mysql:5.7" 
                 }, 
-                new[] { "docker kill tmp-mysql", "docker rm tmp-mysql" }) },
+                new[] { "docker kill tmp-mysql", "docker rm tmp-mysql" },
+                MySqlDefaultPassword) },
             { MongoDb, new EnvironmentToolOption(
                 new[] 
                 { 
@@ -85,11 +118,15 @@ public class EnvironmentToolOption
     {
     }
 
-    public EnvironmentToolOption(string[] startCmds, string[] stopCmds)
+    public EnvironmentToolOption(string[] startCmds, string[] stopCmds, string? defaultPassword = null)
     {
         _startCmds = startCmds;
         _stopCmds = stopCmds;
+        DefaultPassword = defaultPassword;
     }
+
+    [YamlMember(Alias = "DefaultPassword")]
+    public string? DefaultPassword { get; set; }
 
     // Legacy string properties for backward compatibility with old YAML files
     [YamlMember(Alias = "StartCmd")]

--- a/src/AbpDevTools/Configuration/EnvironmentConfiguration.cs
+++ b/src/AbpDevTools/Configuration/EnvironmentConfiguration.cs
@@ -24,7 +24,7 @@ public class EnvironmentConfiguration : DictionaryConfigurationBase<EnvironmentO
                 {
                     Variables = new Dictionary<string, string>
                     {
-                        { "ConnectionStrings__Default", "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;TrustServerCertificate=True" }
+                        { "ConnectionStrings__Default", $"Server=localhost;Database={{AppName}}_{{Today}};User ID=SA;Password={EnvironmentAppConfiguration.SqlServerDefaultPassword};TrustServerCertificate=True" }
                     }
                 }
             },
@@ -42,7 +42,7 @@ public class EnvironmentConfiguration : DictionaryConfigurationBase<EnvironmentO
                 {
                     Variables = new Dictionary<string, string>
                     {
-                        { "ConnectionStrings__Default", "Server=localhost;Port=5432;Database={AppName}_{Today};User Id=postgres;Password=12345678Aa;" }
+                        { "ConnectionStrings__Default", $"Server=localhost;Port=5432;Database={{AppName}}_{{Today}};User Id=postgres;Password={EnvironmentAppConfiguration.PostgreSqlDefaultPassword};" }
                     }
                 }
             },
@@ -51,7 +51,7 @@ public class EnvironmentConfiguration : DictionaryConfigurationBase<EnvironmentO
                 {
                     Variables = new Dictionary<string, string>
                     {
-                        { "ConnectionStrings__Default", "Server=localhost;Port=3306;Database={AppName}_{Today};User Id=root;Password=12345678Aa;" }
+                        { "ConnectionStrings__Default", $"Server=localhost;Port=3306;Database={{AppName}}_{{Today}};User Id=root;Password={EnvironmentAppConfiguration.MySqlDefaultPassword};" }
                     }
                 }
             }

--- a/tests/AbpDevTools.Tests/Configuration/EnvironmentAppConfigurationTests.cs
+++ b/tests/AbpDevTools.Tests/Configuration/EnvironmentAppConfigurationTests.cs
@@ -780,14 +780,71 @@ mysql-with-platform:
         // Arrange
         var startCmds = new[] { "docker start app", "docker run --name app -d image" };
         var stopCmds = new[] { "docker kill app", "docker rm app" };
+        const string defaultPassword = "default-password";
 
         // Act
-        var option = new EnvironmentToolOption(startCmds, stopCmds);
+        var option = new EnvironmentToolOption(startCmds, stopCmds, defaultPassword);
 
         // Assert
         option.StartCmds.Should().BeEquivalentTo(startCmds);
         option.StopCmds.Should().BeEquivalentTo(stopCmds);
+        option.DefaultPassword.Should().Be(defaultPassword);
+    }
+
+    [Theory]
+    [InlineData(EnvironmentAppConfiguration.SqlServer, EnvironmentAppConfiguration.SqlServerDefaultPassword)]
+    [InlineData(EnvironmentAppConfiguration.SqlServerEdge, EnvironmentAppConfiguration.SqlServerDefaultPassword)]
+    [InlineData(EnvironmentAppConfiguration.PostgreSql, EnvironmentAppConfiguration.PostgreSqlDefaultPassword)]
+    [InlineData(EnvironmentAppConfiguration.MySql, EnvironmentAppConfiguration.MySqlDefaultPassword)]
+    public void EnvironmentAppConfiguration_Defaults_ShouldUsePlatformSpecificPasswords(
+        string appName,
+        string expectedPassword)
+    {
+        // Arrange
+        var configuration = new TestEnvironmentAppConfiguration(YamlDeserializer, YamlSerializer);
+
+        // Act
+        var options = configuration.GetDefaultOptions();
+
+        // Assert
+        options[appName].DefaultPassword.Should().Be(expectedPassword);
+    }
+
+    [Fact]
+    public void EnvironmentAppConfiguration_Defaults_ShouldUseCurrentSqlServerPasswordVariable()
+    {
+        // Arrange
+        var configuration = new TestEnvironmentAppConfiguration(YamlDeserializer, YamlSerializer);
+
+        // Act
+        var command = configuration.GetDefaultOptions()[EnvironmentAppConfiguration.SqlServer].StartCmds[1];
+
+        // Assert
+        command.Should().Contain("MSSQL_SA_PASSWORD=Passw0rd");
+        command.Should().NotContain(" SA_PASSWORD=Passw0rd");
+    }
+
+    [Fact]
+    public void EnvironmentAppConfiguration_PostgreSqlStopCommands_ShouldUseCorrectContainerName()
+    {
+        // Arrange
+        var configuration = new TestEnvironmentAppConfiguration(YamlDeserializer, YamlSerializer);
+
+        // Act
+        var commands = configuration.GetDefaultOptions()[EnvironmentAppConfiguration.PostgreSql].StopCmds;
+
+        // Assert
+        commands.Should().OnlyContain(command => command.Contains("tmp-postgres"));
+        commands.Should().NotContain(command => command.Contains("tmp-posgres"));
     }
 
     #endregion
+
+    private sealed class TestEnvironmentAppConfiguration(
+        IDeserializer yamlDeserializer,
+        ISerializer yamlSerializer)
+        : EnvironmentAppConfiguration(yamlDeserializer, yamlSerializer)
+    {
+        public Dictionary<string, EnvironmentToolOption> GetDefaultOptions() => GetDefaults();
+    }
 }

--- a/tests/AbpDevTools.Tests/Configuration/EnvironmentConfigurationTests.cs
+++ b/tests/AbpDevTools.Tests/Configuration/EnvironmentConfigurationTests.cs
@@ -484,4 +484,40 @@ duplicate-var-env:
     }
 
     #endregion
+
+    [Theory]
+    [InlineData(
+        EnvironmentConfiguration.SqlServer,
+        "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=yourStrong(!)Password;TrustServerCertificate=True")]
+    [InlineData(
+        EnvironmentConfiguration.PostgreSql,
+        "Server=localhost;Port=5432;Database={AppName}_{Today};User Id=postgres;Password=postgres;")]
+    [InlineData(
+        EnvironmentConfiguration.MySql,
+        "Server=localhost;Port=3306;Database={AppName}_{Today};User Id=root;Password=root;")]
+    [InlineData(
+        EnvironmentConfiguration.MongoDb,
+        "mongodb://localhost:27017/{AppName}_{Today}")]
+    public void EnvironmentConfiguration_Defaults_ShouldMatchEnvironmentAppCredentials(
+        string environmentName,
+        string expectedConnectionString)
+    {
+        // Arrange
+        var configuration = new TestEnvironmentConfiguration(YamlDeserializer, YamlSerializer);
+
+        // Act
+        var options = configuration.GetDefaultOptions();
+
+        // Assert
+        options[environmentName].Variables["ConnectionStrings__Default"]
+            .Should().Be(expectedConnectionString);
+    }
+
+    private sealed class TestEnvironmentConfiguration(
+        YamlDotNet.Serialization.IDeserializer yamlDeserializer,
+        YamlDotNet.Serialization.ISerializer yamlSerializer)
+        : EnvironmentConfiguration(yamlDeserializer, yamlSerializer)
+    {
+        public Dictionary<string, EnvironmentOption> GetDefaultOptions() => GetDefaults();
+    }
 }


### PR DESCRIPTION
## Summary

- replace the forced `12345678Aa` envapp fallback with per-database development defaults
- keep `-p` / `--password` as an explicit override and migrate existing `environment-tools.yml` entries with `DefaultPassword`
- align default virtual-environment connection strings with the envapp credentials
- use `MSSQL_SA_PASSWORD` for SQL Server and fix the PostgreSQL container name in stop commands
- update the README, DocFX environment documentation, prepare documentation, and environment skill

## Defaults

- SQL Server / SQL Edge: `sa` / `yourStrong(!)Password`
- PostgreSQL: `postgres` / `postgres`
- MySQL: `root` / `root`
- MongoDB and Redis: image defaults without authentication
- RabbitMQ: `guest` / `guest`

These are local-development defaults. The documentation warns against exposing containers with these credentials to untrusted networks.

## Why

A single fallback password did not match the initialization requirements or common development conventions of every supported database. It also made the generated connection strings and Docker containers depend on an unrelated shared value.

## Validation

- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj` — 564 passed
- `docfx docs/docfx.json` — succeeded with 0 errors; only existing API/glob and broken-link warnings
- `git diff --check origin/master...HEAD`