### PR TITLE
Document abpdev.yml configuration

### DIFF
--- a/docs/en/commands/prepare.md
+++ b/docs/en/commands/prepare.md
@@ -5,12 +5,12 @@ title: Prepare Command
 
 # Prepare Command
 
-The `abpvdev prepare` command prepares your ABP project for first-time running on your machine. It automatically detects project dependencies, starts required environment apps, installs ABP libraries, and creates local configuration files.
+The `abpdev prepare` command prepares your ABP project for first-time running on your machine. It automatically detects project dependencies, starts required environment apps, installs ABP libraries, and creates local configuration files.
 
 ## Usage
 
 ```
-abpvdev prepare <workingdirectory> [options]
+abpdev prepare <workingdirectory> [options]
 ```
 
 ## Parameters
@@ -23,7 +23,7 @@ abpvdev prepare <workingdirectory> [options]
 
 | Option | Shortcut | Description |
 |--------|----------|-------------|
-| `--no-config` | | Do not create local configuration file (abpvdev.yml) |
+| `--no-config` | | Do not create local configuration file (`abpdev.yml`) |
 | `--help` | `-h` | Shows help text |
 
 ## Examples
@@ -31,19 +31,19 @@ abpvdev prepare <workingdirectory> [options]
 ### Prepare Current Directory
 
 ```bash
-abpvdev prepare
+abpdev prepare
 ```
 
 ### Prepare Specific Path
 
 ```bash
-abpvdev prepare C:\Path\To\Projects
+abpdev prepare C:\Path\To\Projects
 ```
 
 ### Prepare Without Configuration
 
 ```bash
-abpvdev prepare --no-config
+abpdev prepare --no-config
 ```
 
 Use this when you don't want to create local configuration files.
@@ -81,14 +81,16 @@ Bundles Blazor WASM projects if detected.
 
 ### 5. Configuration
 
-Creates `abpvdev.yml` files with appropriate environment settings.
+Creates `abpdev.yml` files with appropriate environment settings.
 
-## Configuration File
+## `abpdev.yml` Configuration
 
-After running prepare, you'll have an `abpvdev.yml` file in your project directory. This file contains:
+After running prepare, you'll have an `abpdev.yml` file in your project directory. This file contains:
 - Database connection strings
 - Environment variables
 - Custom settings
+
+See the [`abpdev.yml` configuration reference](../configuration.md) for the complete schema, file lookup rules, project-level overrides, and command-line precedence.
 
 ### Placeholders
 
@@ -96,14 +98,14 @@ The configuration supports these placeholders:
 
 | Placeholder | Description |
 |-------------|-------------|
-| `{AppName}` | Application name (folder name if not detected) |
-| `{Today}` | Current date (useful for separate databases per day) |
+| `{AppName}` | Normalized application name derived from the target application's working directory |
+| `{Today}` | Current local date in `yyyyMMdd` format |
 
 Example:
-```json
-{
-  "ConnectionStrings__Default": "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;"
-}
+```yaml
+environment:
+  variables:
+    ConnectionStrings__Default: "Server=localhost;Database={AppName}_{Today};User ID=SA;Password=12345678Aa;"
 ```
 
 ## Troubleshooting

--- a/docs/en/commands/run.md
+++ b/docs/en/commands/run.md
@@ -10,7 +10,7 @@ The `abpdev run` command runs the solution in the current directory. It supports
 ## Usage
 
 ```
-abpvdev run <workingdirectory> [options]
+abpdev run <workingdirectory> [options]
 ```
 
 ## Parameters
@@ -28,11 +28,15 @@ abpvdev run <workingdirectory> [options]
 | `--all` | `-a` | Run all projects without prompting |
 | `--no-build` | | Skip build before running |
 | `--install-libs` | `-i` | Run 'abp install-libs' while running |
+| `--skip-check-libs` | | Skip the `wwwroot/libs` check before running |
 | `--graphBuild` | `-g` | Use /graphBuild for building |
 | `--projects` | `-p` | Names or part of names of projects to run |
 | `--msbuild-property` | | MSBuild property passed to every selected `dotnet run` process. Use `Name=Value`; repeat for multiple properties |
 | `--configuration` | `-c` | Build configuration (Debug/Release) |
 | `--env` | `-e` | Virtual environment name |
+| `--retry` | `-r` | Restart an application when it exits |
+| `--verbose` | `-v` | Show verbose application output |
+| `--yml` | | Path to an alternate root YAML configuration |
 | `--help` | `-h` | Shows help text |
 
 ## Examples
@@ -40,31 +44,31 @@ abpvdev run <workingdirectory> [options]
 ### Run in Current Directory
 
 ```bash
-abpvdev run
+abpdev run
 ```
 
 ### Run in Specific Path
 
 ```bash
-abpvdev run C:\Path\To\Projects
+abpdev run C:\Path\To\Projects
 ```
 
 ### Run in Release Mode
 
 ```bash
-abpvdev run -c Release
+abpdev run -c Release
 ```
 
 ### Run All Projects Without Prompt
 
 ```bash
-abpvdev run -a
+abpdev run -a
 ```
 
 ### Skip Migration
 
 ```bash
-abpvdev run --skip-migrate
+abpdev run --skip-migrate
 ```
 
 Useful when you don't need to apply migrations.
@@ -72,7 +76,7 @@ Useful when you don't need to apply migrations.
 ### Watch Mode
 
 ```bash
-abpvdev run -w
+abpdev run -w
 ```
 
 Automatically rebuilds and restarts when source files change.
@@ -82,7 +86,7 @@ Automatically rebuilds and restarts when source files change.
 ### Run with Virtual Environment
 
 ```bash
-abpvdev run -e SqlServer
+abpdev run -e SqlServer
 ```
 
 Uses the SqlServer virtual environment configuration.
@@ -90,13 +94,13 @@ Uses the SqlServer virtual environment configuration.
 ### Run Specific Projects
 
 ```bash
-abpvdev run -p MyApp.Web.HttpApi.Host
+abpdev run -p MyApp.Web.HttpApi.Host
 ```
 
 ### Run with ABP Library Installation
 
 ```bash
-abpvdev run --install-libs
+abpdev run --install-libs
 ```
 
 Runs `abp install-libs` automatically while starting the application.
@@ -141,19 +145,16 @@ run:
       - start
 ```
 
-## Configuration
+## `abpdev.yml` Configuration
 
-Use the `abpvdev run config` command to customize:
-- Project name conventions
-- Default options
-- Environment variables
+Use [`abpdev.yml`](../configuration.md) to define default project selection, run options, npm scripts, MSBuild properties, and environment variables. A solution-root file can configure all applications, while a nearer file can override launch settings for one project.
 
 ## Multiple Solutions
 
 When multiple solutions exist in the directory:
 
 ```bash
-abpvdev run
+abpdev run
 ```
 
 You'll be prompted to select which solution to run.
@@ -164,7 +165,7 @@ You'll be prompted to select which solution to run.
 
 ### Application Doesn't Start
 
-1. Check that all dependencies are installed: `abpvdev prepare`
+1. Check that all dependencies are installed: `abpdev prepare`
 2. Verify database connections in configuration
 3. Check for port conflicts
 
@@ -174,4 +175,4 @@ Use the `--projects` option to run specific projects, or stop other running appl
 
 ### Missing Dependencies
 
-Run `abpvdev prepare` to install all required dependencies.
+Run `abpdev prepare` to install all required dependencies.

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -1,201 +1,203 @@
 ---
 id: configuration
-title: Configuration
+title: abpdev.yml Configuration
 ---
 
-# Configuration
+# `abpdev.yml` Configuration
 
-AbpDevTools uses YAML configuration files to customize its behavior. This guide covers all configuration options.
+`abpdev.yml` is the project-local configuration file used by `abpdev run`. It can define solution-wide project selection and migration behavior, as well as launch settings and environment variables for individual .NET and npm applications.
 
-## Configuration Files
+The file has two top-level sections:
 
-### Main Configuration File
+- `run` configures application discovery, selection, and launch behavior.
+- `environment` applies a named virtual environment and custom environment variables to launched processes.
 
-The primary configuration file is `abpvdev.yml` in your project directory.
+`abpdev prepare` can generate an `abpdev.yml` containing the detected environment. You can then add any of the settings documented below.
 
-### Configuration Locations
-
-AbpDevTools looks for configuration in this order:
-1. `.abpvdev.yml` (local, not committed to version control)
-2. `abpvdev.yml` (project-level)
-3. `~/.abpvdev.yml` (user-level global config)
-
-Settings from later files override earlier ones.
-
-## Configuration Sections
-
-### Run Configuration
-
-Customize how projects are run:
+## Complete Example
 
 ```yaml
 run:
-  # Application project naming patterns
-  application:
-    - "*Web.Host"
-    - "*HttpApi.Host"
-    - "*Web"
-  
-  # DbMigrator pattern
-  dbmigrator:
-    - "*DbMigrator"
-  
-  # Blazor WASM pattern
-  blazor:
-    - "*Blazor.Web"
-    - "*Blazor.Client"
-
-  # MSBuild properties passed to dotnet run for this configuration scope
-  msbuild-properties:
-    UseMudBlazor: true
-```
-
-Place `abpdev.yml` beside a specific project file to apply `run.msbuild-properties` only to that project during batch runs.
-
-### Build Configuration
-
-```yaml
-build:
-  # Build configuration
+  watch: false
+  no-build: false
+  graph-build: false
   configuration: Debug
-  
-  # Project patterns to include
+  skip-migrate: false
+  skip-check-libs: false
   projects:
-    - "*.sln"
-    - "*.csproj"
-  
-  # Projects to exclude
-  exclude:
-    - "*.Tests.csproj"
+    - MyApp.HttpApi.Host
+    - angular
+  msbuild-properties:
+    UseMudBlazor: "true"
+    DefineConstants: "FEATURE_A;FEATURE_B"
+  npm:
+    scripts:
+      - start:dev
+      - dev
+
+environment:
+  name: SqlServer
+  variables:
+    ASPNETCORE_ENVIRONMENT: Development
+    ConnectionStrings__Default: "Server=localhost;Database={AppName}_{Today};Trusted_Connection=True;TrustServerCertificate=True"
 ```
 
-### Replacement Configuration
+All property names use hyphen-case. Environment variable names and MSBuild property names keep their original casing.
+
+## File Lookup
+
+For `abpdev run <working-directory>`, AbpDevTools loads `<working-directory>/abpdev.yml` as the root configuration. It does not look for `.abpdev.yml` or a user-level `abpdev.yml`.
+
+When each application is launched, AbpDevTools searches for the nearest `abpdev.yml`, starting in the application's directory and continuing through its parent directories. The first file found is used for that application. Files are not merged, so a nearer project file replaces the root file for project launch and environment settings.
+
+Use a project-level file when one application needs different launch settings:
+
+```text
+MySolution/
+|-- abpdev.yml
+|-- services/
+|   `-- orders/
+|       |-- OrdersService.csproj
+|       `-- abpdev.yml
+```
+
+The root file can select all applications:
 
 ```yaml
-replacement:
-  ConnectionStrings:
-    FilePattern: "appsettings*.json"
-    Find: "Trusted_Connection=True;"
-    Replace: "User ID=SA;Password=12345678Aa;"
+run:
+  projects:
+    - MyApp.HttpApi.Host
+    - OrdersService
 ```
 
-### Environment Variables
+The nearer `services/orders/abpdev.yml` can configure only the orders service:
+
+```yaml
+run:
+  configuration: Release
+  msbuild-properties:
+    EnablePreviewFeatures: "true"
+
+environment:
+  name: PostgreSql
+```
+
+Because files are not merged, repeat any root launch or environment settings that the project-level file should retain.
+
+### Alternate Root File
+
+The `--yml` option loads an alternate root configuration:
+
+```bash
+abpdev run --yml profiles/development.yml
+```
+
+The alternate file controls root-scoped settings such as `projects`, `skip-migrate`, `skip-check-libs`, and `npm.scripts`. Application launch settings still use the nearest file named `abpdev.yml`.
+
+## `run` Section
+
+| Property | Type | Default | Scope and behavior |
+|----------|------|---------|--------------------|
+| `watch` | Boolean | `false` | Uses `dotnet watch` for .NET applications. Read from the nearest application configuration when it has a `run` section. |
+| `no-build` | Boolean | `false` | Passes `--no-build` to `dotnet run`. Read from the nearest application configuration. |
+| `graph-build` | Boolean | `false` | Passes `/graphBuild` to `dotnet run`. Read from the nearest application configuration. |
+| `configuration` | String | Not set | Passes `--configuration <value>` to `dotnet run`. Read from the nearest application configuration. |
+| `skip-migrate` | Boolean | `false` | Skips the migration step before applications start. Read from the root configuration. |
+| `skip-check-libs` | Boolean | `false` | Skips the `wwwroot/libs` check and installation prompt. Read from the root configuration. |
+| `projects` | String array | Empty | Selects applications using case-insensitive name or path fragments. Read from the root configuration. |
+| `msbuild-properties` | Mapping | Empty | Passes each entry as `--property:Name=Value` to `dotnet run`. Read from the nearest application configuration. |
+| `npm.scripts` | String array | Empty | Lists npm script names in priority order. Read from the root configuration. |
+
+### Project Selection
+
+`run.projects` has the same matching behavior as the `--projects` command-line option. Each value is a case-insensitive fragment matched against the application name, path, or npm display name.
+
+```yaml
+run:
+  projects:
+    - HttpApi.Host
+    - angular
+```
+
+When `--projects` is supplied on the command line, it replaces `run.projects`.
+
+### MSBuild Properties
+
+`run.msbuild-properties` is a mapping of MSBuild property names to values:
+
+```yaml
+run:
+  msbuild-properties:
+    UseMudBlazor: "true"
+    DefineConstants: "FEATURE_A;FEATURE_B"
+    EmptyValue:
+```
+
+Quote values that contain spaces, semicolons, or YAML boolean-like values. A null value is passed as an empty value.
+
+Command-line `--msbuild-property Name=Value` entries are merged with the file. A command-line entry replaces a file entry with the same name, using a case-insensitive comparison.
+
+### npm Scripts
+
+For each `package.json`, AbpDevTools uses the first configured script that exists:
+
+```yaml
+run:
+  npm:
+    scripts:
+      - start:dev
+      - dev
+      - serve
+```
+
+If none of the configured scripts exist, discovery falls back to `dev`, then `serve`, then `start`. A configured script is considered safe for automatic execution, including with `abpdev run --all`.
+
+## `environment` Section
+
+| Property | Type | Default | Behavior |
+|----------|------|---------|----------|
+| `name` | String | Not set | Applies a virtual environment configured by `abpdev env config`. |
+| `variables` | String mapping | Empty | Sets or replaces environment variables for the launched process. |
 
 ```yaml
 environment:
-  Variables:
-    ConnectionStrings__Default: "Server=localhost;Database=MyApp"
-    AuthServer__Authority: "https://localhost:44350"
+  name: SqlServer
+  variables:
+    ASPNETCORE_ENVIRONMENT: Development
+    Redis__Configuration: localhost:6379
 ```
 
-### Virtual Environments
+The named virtual environment is applied first. Values in `environment.variables` are applied afterward and replace variables with the same name.
 
-```yaml
-Environments:
-  SqlServer:
-    Variables:
-      ConnectionStrings__Default: "Server=localhost;Database={AppName}_{Today}..."
-  MongoDB:
-    Variables:
-      ConnectionStrings__Default: "mongodb://localhost:27017/{AppName}"
-```
+The variables are applied only to processes started by `abpdev run`; they do not modify the parent shell or machine environment.
 
-### Environment Apps
+### Value Placeholders
 
-```yaml
-environmentApps:
-  sqlserver:
-    Image: "mcr.microsoft.com/mssql/server"
-    Ports:
-      "1433": "1433"
-    Environment:
-      ACCEPT_EULA: "Y"
-      SA_PASSWORD: "yourpassword"
-```
+Environment variable values support these placeholders:
 
-### Local Sources
-
-```yaml
-localSources:
-  abp:
-    Path: C:\github\abp
-    Packages:
-      - Volo.Abp.*
-```
-
-## Managing Configuration
-
-### Edit Configuration
-
-Use the config command:
-
-```bash
-abpvdev config
-```
-
-### Clear Configuration
-
-```bash
-abpvdev config clear
-```
-
-## Placeholders
-
-Use placeholders in configuration values:
-
-| Placeholder | Description |
+| Placeholder | Replacement |
 |-------------|-------------|
-| `{AppName}` | Application name (folder name if not detected) |
-| `{Today}` | Current date (yyyy-MM-dd format) |
+| `{Today}` | Current local date in `yyyyMMdd` format. |
+| `{AppName}` | A normalized application name derived from the target application's working directory. |
 
-## Examples
+## Command-Line Precedence
 
-### Development Setup
+| Setting | Effective value |
+|---------|-----------------|
+| `watch` | Nearest application configuration when it has a `run` section; otherwise command-line `--watch`. |
+| `no-build`, `graph-build` | Enabled when either the command-line option or nearest application configuration is `true`. |
+| `skip-migrate`, `skip-check-libs` | Enabled when either the command-line option or root configuration is `true`. |
+| `projects` | Command-line `--projects` when supplied; otherwise root `run.projects`. |
+| `configuration` | Nearest application configuration when set; otherwise command-line `--configuration`. |
+| `msbuild-properties` | File and command-line mappings are merged; command-line values replace duplicate names. |
+| `environment` | The nearest file's named environment, then its variables, then command-line `--env`; later values replace duplicate variables. |
 
-```yaml
-run:
-  application:
-    - "*Web.Host"
+The `no-build`, `graph-build`, `skip-migrate`, and `skip-check-libs` options are additive: there is no command-line option that changes a `true` file value back to `false`.
 
-Environments:
-  Development:
-    Variables:
-      ConnectionStrings__Default: "Server=localhost;Database=MyApp_Dev"
-```
+## Related Configuration
 
-### Production Setup
+`abpdev.yml` is separate from the global configuration files managed by other commands:
 
-```yaml
-run:
-  application:
-    - "*Web.Host"
-
-Environments:
-  Production:
-    Variables:
-      ConnectionStrings__Default: "Server=prodserver;Database=MyApp_Prod;User=produser;Password=secret"
-```
-
-## Configuration Commands
-
-| Command | Description |
-|---------|-------------|
-| `abpvdev config` | Open configuration file |
-| `abpvdev config clear` | Clear all configuration |
-| `abpvdev run config` | Configure run settings |
-| `abpvdev replace config` | Configure replacements |
-| `abpvdev references config` | Configure local sources |
-| `abpvdev env config` | Configure virtual environments |
-| `abpvdev envapp config` | Configure environment apps |
-
-## Troubleshooting
-
-### Configuration Not Applied
-
-1. Check file location and name (must be `abpvdev.yml`)
-2. Verify YAML syntax (use a YAML validator)
-3. Check for typos in section names
-
-### Settings Override
-
-Remember that later configuration files override earlier ones. Check all possible locations.
+- [Virtual Environments](environment/virtual-environments.md) defines reusable named environment variable sets.
+- [Environment Apps](environment/environment-apps.md) configures infrastructure applications such as database and cache containers.
+- [Local Sources](references/local-sources.md) maps NuGet packages to local source repositories.

--- a/docs/en/toc.yml
+++ b/docs/en/toc.yml
@@ -41,7 +41,7 @@ items:
         href: environment/virtual-environments.md
       - name: Environment Apps
         href: environment/environment-apps.md
-  - name: Configuration
+  - name: abpdev.yml Configuration
     href: configuration.md
   - name: Notifications
     href: notifications.md


### PR DESCRIPTION
## What changed

- replaced the stale generic configuration page with a dedicated `abpdev.yml` reference
- documented the complete `run` and `environment` schema, defaults, file lookup, project-level overrides, npm script selection, placeholders, and command-line precedence
- added direct links from the Run and Prepare command pages and corrected their related `abpvdev` typos
- renamed the documentation navigation entry to make the file reference discoverable

## Why

The existing page mentioned the wrong file name (`abpvdev.yml`) and described unsupported locations, sections, and commands. Users did not have an accurate reference for the arguments accepted by the real `LocalConfiguration` model.

## Impact

Users can now configure solution-wide and per-project run behavior without reading source code, including non-obvious behaviors such as nearest-file replacement, root-only settings, `--yml` scope, and option precedence.

## Validation

- `docfx docs/docfx.json` (build succeeded; only pre-existing unrelated warnings)
- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj --nologo` (554 passed)
- `git diff --check`