### PR TITLE
Load nearest ancestor abpdev.yml in run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 
 ## Config And Discovery Quirks
 - Global tool config lives under `%AppData%/abpdev` as YAML files such as `tools-configuration.yml` and `replacements.yml`. Legacy JSON config is auto-migrated on read.
-- Repo/project-local overrides live in `abpdev.yml`. `PrepareCommand` creates it; `RunCommand` loads the root file from `WorkingDirectory`; per-project loads search ancestor folders via `LocalConfigurationManager`.
+- Repo/project-local overrides live in `abpdev.yml`. `PrepareCommand` creates it; `RunCommand` loads the nearest root file from `WorkingDirectory` or its parents; per-project loads also search ancestor folders via `LocalConfigurationManager`.
 - Do not build new behavior on `RunConfiguration`. It is `[Obsolete]`, and `RunnableProjectsProvider` deletes `run-configuration.yml` on startup.
 - Runnable project discovery is now heuristic-based: any `*.csproj` with sibling `Program.cs` is runnable. Migrate fallback also scans `Program.cs` and top-level `*Module.cs` for `--migrate-database`.
 

--- a/docs/en/commands/run.md
+++ b/docs/en/commands/run.md
@@ -36,7 +36,7 @@ abpdev run <workingdirectory> [options]
 | `--env` | `-e` | Virtual environment name |
 | `--retry` | `-r` | Restart an application when it exits |
 | `--verbose` | `-v` | Show verbose application output |
-| `--yml` | | Path to an alternate root YAML configuration |
+| `--yml` | | Exact path to an alternate root YAML configuration |
 | `--help` | `-h` | Shows help text |
 
 ## Examples
@@ -148,6 +148,8 @@ run:
 ## `abpdev.yml` Configuration
 
 Use [`abpdev.yml`](../configuration.md) to define default project selection, run options, npm scripts, MSBuild properties, and environment variables. A solution-root file can configure all applications, while a nearer file can override launch settings for one project.
+
+Without `--yml`, root configuration lookup starts in the working directory and continues through its parents. The nearest `abpdev.yml` is used. Files are not merged.
 
 ## Multiple Solutions
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -108,7 +108,7 @@ These options do not have an `abpdev.yml` property:
 
 ## File Lookup
 
-For `abpdev run <working-directory>`, AbpDevTools loads `<working-directory>/abpdev.yml` as the root configuration. It does not look for `.abpdev.yml` or a user-level `abpdev.yml`.
+For `abpdev run <working-directory>`, AbpDevTools searches for `abpdev.yml` in the working directory and then each parent directory. The nearest file is used as the root configuration. It does not look for `.abpdev.yml` or use a separate user-level configuration location.
 
 When each application is launched, AbpDevTools searches for the nearest `abpdev.yml`, starting in the application's directory and continuing through its parent directories. The first file found is used for that application. Files are not merged, so a nearer project file replaces the root file for project launch and environment settings.
 
@@ -148,13 +148,13 @@ Because files are not merged, repeat any root launch or environment settings tha
 
 ### Alternate Root File
 
-The `--yml` option loads an alternate root configuration:
+The `--yml` option loads an alternate root configuration by its exact path:
 
 ```bash
 abpdev run --yml profiles/development.yml
 ```
 
-The alternate file controls root-scoped settings such as `projects`, `skip-migrate`, `skip-check-libs`, and `npm.scripts`. Application launch settings still use the nearest file named `abpdev.yml`.
+The alternate file controls root-scoped settings such as `projects`, `skip-migrate`, `skip-check-libs`, and `npm.scripts`. Application launch settings still use the nearest file named `abpdev.yml`. The command fails when the explicitly selected file does not exist.
 
 ## `run` Section
 

--- a/skills/abpdev-workflow/SKILL.md
+++ b/skills/abpdev-workflow/SKILL.md
@@ -66,11 +66,11 @@ Useful options:
 - `-e`, `--env`: apply a configured virtual environment
 - `-r`, `--retry`: retry when apps exit
 - `-v`, `--verbose`: show verbose project output
-- `--yml`: explicitly point to an `abpdev.yml`
+- `--yml`: explicitly point to an exact `abpdev.yml` path
 
 Behavior:
 
-- Loads `abpdev.yml` from the working directory when present
+- Loads the nearest `abpdev.yml` from the working directory or its parents
 - Runs migrators first unless skipped
 - Prompts for project selection when multiple runnable apps are found and interactive input is available
 - Can detect missing `wwwroot/libs` and offer to run `abp install-libs`

--- a/src/AbpDevTools/Commands/RunCommand.cs
+++ b/src/AbpDevTools/Commands/RunCommand.cs
@@ -55,7 +55,7 @@ public partial class RunCommand : ICommand
     [CommandOption("verbose", 'v', Description = "Shows verbose output from the projects.")]
     public bool Verbose { get; set; }
 
-    [CommandOption("yml", Description = "Path to the yml file to be used for running the project.")]
+    [CommandOption("yml", Description = "Exact path to the root yml file to be used for running the project.")]
     public string? YmlPath { get; set; }
 
     protected IConsole? console;
@@ -107,16 +107,11 @@ public partial class RunCommand : ICommand
             WorkingDirectory = Directory.GetCurrentDirectory();
         }
 
-        if (string.IsNullOrEmpty(YmlPath))
-        {
-            YmlPath = Path.Combine(WorkingDirectory, "abpdev.yml");
-        }
-
         var cancellationToken = console.RegisterCancellationHandler();
 
-        if (localConfigurationManager.TryLoad(YmlPath!, out var localRootConfig, FileSearchDirection.OnlyCurrent))
+        if (TryLoadRootConfiguration(out var localRootConfig, out var loadedYmlPath))
         {
-            console.Output.WriteLine($"Loaded YAML configuration from '{YmlPath}' with environment '{localRootConfig?.Environment?.Name ?? "Default"}'.");
+            console.Output.WriteLine($"Loaded YAML configuration from '{loadedYmlPath}' with environment '{localRootConfig?.Environment?.Name ?? "Default"}'.");
         }
 
         var commandLineMsbuildProperties = ParseCommandLineMsbuildProperties();
@@ -324,6 +319,38 @@ public partial class RunCommand : ICommand
             keyInputManager.StopListening();
             AppDomain.CurrentDomain.ProcessExit -= ProcessExitHandler;
         }
+    }
+
+    protected bool TryLoadRootConfiguration(
+        out LocalConfiguration? localConfiguration,
+        out string? loadedPath)
+    {
+        var hasExplicitYmlPath = !string.IsNullOrEmpty(YmlPath);
+        var configurationPath = hasExplicitYmlPath
+            ? YmlPath!
+            : Path.Combine(WorkingDirectory!, "abpdev.yml");
+        var searchDirection = hasExplicitYmlPath
+            ? FileSearchDirection.OnlyCurrent
+            : FileSearchDirection.Ascendants;
+
+        if (localConfigurationManager.TryLoad(
+            configurationPath,
+            out localConfiguration,
+            out loadedPath,
+            searchDirection))
+        {
+            YmlPath = loadedPath;
+            return true;
+        }
+
+        YmlPath = configurationPath;
+
+        if (hasExplicitYmlPath)
+        {
+            throw new CommandException($"YAML configuration file '{configurationPath}' was not found.");
+        }
+
+        return false;
     }
 
     private void ApplyLocalProjects(LocalConfiguration? localConfiguration)

--- a/src/AbpDevTools/LocalConfigurations/LocalConfigurationManager.cs
+++ b/src/AbpDevTools/LocalConfigurations/LocalConfigurationManager.cs
@@ -47,7 +47,17 @@ public class LocalConfigurationManager
 
     public bool TryLoad(string path, out LocalConfiguration? localConfiguration, FileSearchDirection direction = FileSearchDirection.Ascendants)
     {
+        return TryLoad(path, out localConfiguration, out _, direction);
+    }
+
+    public bool TryLoad(
+        string path,
+        out LocalConfiguration? localConfiguration,
+        out string? loadedPath,
+        FileSearchDirection direction = FileSearchDirection.Ascendants)
+    {
         localConfiguration = null;
+        loadedPath = null;
 
         var directory = Path.GetDirectoryName(path);
         if (directory == null)
@@ -75,7 +85,8 @@ public class LocalConfigurationManager
             return false;
         }
 
-        var ymlContent = File.ReadAllText(ymlPath);
+        loadedPath = Path.GetFullPath(ymlPath);
+        var ymlContent = File.ReadAllText(loadedPath);
 
         localConfiguration = _deserializer.Deserialize<LocalConfiguration>(ymlContent);
 

--- a/tests/AbpDevTools.Tests/Commands/RunCommand_ConfigurationTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/RunCommand_ConfigurationTests.cs
@@ -1,0 +1,137 @@
+using AbpDevTools.Commands;
+using AbpDevTools.Environments;
+using AbpDevTools.LocalConfigurations;
+using AbpDevTools.Notifications;
+using AbpDevTools.Services;
+using CliFx.Exceptions;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace AbpDevTools.Tests.Commands;
+
+public class RunCommand_ConfigurationTests : IDisposable
+{
+    private readonly string _testRootPath;
+    private readonly TestRunCommand _command;
+
+    public RunCommand_ConfigurationTests()
+    {
+        _testRootPath = Path.Combine(Path.GetTempPath(), $"AbpDevTools_RunConfig_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRootPath);
+
+        var environmentManager = Substitute.For<IProcessEnvironmentManager>();
+        var fileExplorer = new FileExplorer();
+        var localConfigurationManager = new LocalConfigurationManager(
+            new DeserializerBuilder()
+                .WithNamingConvention(HyphenatedNamingConvention.Instance)
+                .Build(),
+            new SerializerBuilder()
+                .WithNamingConvention(HyphenatedNamingConvention.Instance)
+                .Build(),
+            fileExplorer,
+            environmentManager);
+
+        _command = new TestRunCommand(localConfigurationManager, environmentManager, fileExplorer);
+    }
+
+    [Fact]
+    public void TryLoadRootConfiguration_WithoutYmlOption_LoadsNearestAncestor()
+    {
+        var workspacePath = Path.Combine(_testRootPath, "workspace");
+        var workingDirectory = Path.Combine(workspacePath, "src", "service");
+        Directory.CreateDirectory(workingDirectory);
+
+        File.WriteAllText(Path.Combine(_testRootPath, "abpdev.yml"), "run:\n  configuration: Debug\n");
+        var nearestConfigurationPath = Path.Combine(workspacePath, "abpdev.yml");
+        File.WriteAllText(nearestConfigurationPath, "run:\n  configuration: Release\n");
+
+        _command.WorkingDirectory = workingDirectory;
+
+        var result = _command.InvokeTryLoadRootConfiguration(out var configuration, out var loadedPath);
+
+        result.Should().BeTrue();
+        configuration!.Run!.Configuration.Should().Be("Release");
+        loadedPath.Should().Be(Path.GetFullPath(nearestConfigurationPath));
+        _command.YmlPath.Should().Be(loadedPath);
+    }
+
+    [Fact]
+    public void TryLoadRootConfiguration_WithYmlOption_LoadsExactFile()
+    {
+        var workingDirectory = Path.Combine(_testRootPath, "workspace", "src");
+        Directory.CreateDirectory(workingDirectory);
+        File.WriteAllText(Path.Combine(workingDirectory, "abpdev.yml"), "run:\n  configuration: Debug\n");
+
+        var explicitConfigurationPath = Path.Combine(_testRootPath, "profiles", "release.yml");
+        Directory.CreateDirectory(Path.GetDirectoryName(explicitConfigurationPath)!);
+        File.WriteAllText(explicitConfigurationPath, "run:\n  configuration: Release\n");
+
+        _command.WorkingDirectory = workingDirectory;
+        _command.YmlPath = explicitConfigurationPath;
+
+        var result = _command.InvokeTryLoadRootConfiguration(out var configuration, out var loadedPath);
+
+        result.Should().BeTrue();
+        configuration!.Run!.Configuration.Should().Be("Release");
+        loadedPath.Should().Be(Path.GetFullPath(explicitConfigurationPath));
+    }
+
+    [Fact]
+    public void TryLoadRootConfiguration_WithMissingYmlOption_DoesNotSearchParents()
+    {
+        var workingDirectory = Path.Combine(_testRootPath, "workspace", "src");
+        Directory.CreateDirectory(workingDirectory);
+        File.WriteAllText(Path.Combine(_testRootPath, "custom.yml"), "run:\n  configuration: Release\n");
+
+        _command.WorkingDirectory = workingDirectory;
+        _command.YmlPath = Path.Combine(workingDirectory, "custom.yml");
+
+        var act = () => _command.InvokeTryLoadRootConfiguration(out _, out _);
+
+        act.Should().Throw<CommandException>()
+            .WithMessage("*custom.yml*was not found*");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_testRootPath, recursive: true);
+        }
+        catch
+        {
+            // Ignore cleanup errors.
+        }
+    }
+
+    [CliFx.Attributes.Command("test-run-configuration-command")]
+    private sealed class TestRunCommand : RunCommand
+    {
+        public TestRunCommand(
+            LocalConfigurationManager localConfigurationManager,
+            IProcessEnvironmentManager environmentManager,
+            FileExplorer fileExplorer)
+            : base(
+                Substitute.For<INotificationManager>(),
+                null!,
+                environmentManager,
+                null!,
+                null!,
+                null!,
+                fileExplorer,
+                localConfigurationManager,
+                Substitute.For<IKeyInputManager>())
+        {
+        }
+
+        public bool InvokeTryLoadRootConfiguration(
+            out LocalConfiguration? localConfiguration,
+            out string? loadedPath)
+        {
+            return TryLoadRootConfiguration(out localConfiguration, out loadedPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- search the working directory and its parents for the nearest root `abpdev.yml` when `--yml` is omitted
- keep `--yml` as an exact-path override and fail clearly when that file is missing
- report the resolved configuration path and document the lookup rules
- cover nearest-ancestor and explicit-path behavior with focused tests

Configuration files are selected, not merged.

## Testing

- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj` (557 passed)
- `dotnet build AbpDevTools.sln`
