### PR TITLE
Load migrate project filters from abpdev.yml

### DIFF
--- a/src/AbpDevTools/Commands/MigrateCommand.cs
+++ b/src/AbpDevTools/Commands/MigrateCommand.cs
@@ -51,7 +51,15 @@ public class MigrateCommand : ICommand
         this.runnableProjectsProvider = runnableProjectsProvider;
     }
 
-    public async ValueTask ExecuteAsync(IConsole console)
+    public ValueTask ExecuteAsync(IConsole console)
+    {
+        return ExecuteAsync(console, localRootConfiguration: null, rootConfigurationLoaded: false);
+    }
+
+    internal async ValueTask ExecuteAsync(
+        IConsole console,
+        LocalConfiguration? localRootConfiguration,
+        bool rootConfigurationLoaded)
     {
         this.console = console;
         if (string.IsNullOrEmpty(WorkingDirectory))
@@ -59,21 +67,23 @@ public class MigrateCommand : ICommand
             WorkingDirectory = Directory.GetCurrentDirectory();
         }
 
-        var dbMigrators = Directory.EnumerateFiles(WorkingDirectory, "*.csproj", SearchOption.AllDirectories)
-           .Where(IsDbMigrator)
-           .Select(x => new FileInfo(x))
-           .ToList();
+        LoadLocalConfiguration(console, localRootConfiguration, rootConfigurationLoaded);
+
+        var dbMigrators = FindDbMigrators(out var discoveredDbMigratorCount);
 
         var cancellationToken = console.RegisterCancellationHandler();
 
-        if (dbMigrators.Count == 0)
+        if (dbMigrators.Length == 0)
         {
-            await console.Output.WriteLineAsync($"No migrator(s) found in this folder. Migration not applied.");
+            var message = discoveredDbMigratorCount > 0
+                ? "No db migrator matched the specified project filters."
+                : "No migrator(s) found in this folder. Migration not applied.";
+            await console.Output.WriteLineAsync(message);
             await RunParameterMigrationFallbackAsync();
             return;
         }
 
-        await console.Output.WriteLineAsync($"{dbMigrators.Count} db migrator(s) found.");
+        await console.Output.WriteLineAsync($"{dbMigrators.Length} db migrator(s) found.");
 
         var commandPostFix = NoBuild ? " --no-build" : string.Empty;
 
@@ -117,6 +127,65 @@ public class MigrateCommand : ICommand
         KillRunningProcesses();
     }
 
+    protected void LoadLocalConfiguration(
+        IConsole console,
+        LocalConfiguration? localRootConfiguration = null,
+        bool rootConfigurationLoaded = false)
+    {
+        if (!rootConfigurationLoaded &&
+            TryLoadRootConfiguration(out localRootConfiguration, out var loadedYmlPath))
+        {
+            console.Output.WriteLine($"Loaded YAML configuration from '{loadedYmlPath}' with environment '{localRootConfiguration?.Environment?.Name ?? "Default"}'.");
+        }
+
+        ApplyLocalProjects(localRootConfiguration);
+    }
+
+    protected bool TryLoadRootConfiguration(
+        out LocalConfiguration? localConfiguration,
+        out string? loadedPath)
+    {
+        return localConfigurationManager.TryLoad(
+            Path.Combine(WorkingDirectory!, "abpdev.yml"),
+            out localConfiguration,
+            out loadedPath);
+    }
+
+    private void ApplyLocalProjects(LocalConfiguration? localConfiguration)
+    {
+        if (Projects.Length == 0 && localConfiguration?.Run?.Projects.Length > 0)
+        {
+            Projects = localConfiguration.Run.Projects;
+        }
+    }
+
+    protected FileInfo[] FindDbMigrators(out int discoveredCount)
+    {
+        var dbMigrators = Directory
+            .EnumerateFiles(WorkingDirectory!, "*.csproj", SearchOption.AllDirectories)
+            .Where(IsDbMigrator)
+            .Select(path => new FileInfo(path))
+            .ToArray();
+
+        discoveredCount = dbMigrators.Length;
+        return FilterProjects(dbMigrators);
+    }
+
+    private FileInfo[] FilterProjects(IEnumerable<FileInfo> projectFiles)
+    {
+        var projects = projectFiles.ToArray();
+
+        if (RunAll || Projects.Length == 0)
+        {
+            return projects;
+        }
+
+        return projects
+            .Where(project => Projects.Any(filter =>
+                project.FullName.Contains(filter, StringComparison.InvariantCultureIgnoreCase)))
+            .ToArray();
+    }
+
     protected async Task RunParameterMigrationFallbackAsync()
     {
         var canUseInteractiveConsole = global::AbpDevTools.ConsoleSupport.SupportsInteractiveConsole(console);
@@ -146,35 +215,34 @@ public class MigrateCommand : ICommand
             return;
         }
 
-        var projectFiles = csprojs;
+        var projectFiles = FilterProjects(csprojs);
 
-        if (!RunAll && projectFiles.Length > 1)
+        if (projectFiles.Length == 0)
         {
-            if (Projects.Length == 0)
-            {
-                if (canUseInteractiveConsole)
-                {
-                    var selectedProjects = AnsiConsole.Prompt(
-                        new MultiSelectionPrompt<FileInfo>()
-                            .Title("Select project(s) to run with '--migrate-database' parameter")
-                            .Required(true)
-                            .PageSize(10)
-                            .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
-                            .InstructionsText("[grey](Press [blue]<space>[/] to toggle a project, [green]<enter>[/] to accept)[/]")
-                            .UseConverter(file => Path.GetRelativePath(WorkingDirectory!, file.FullName))
-                            .AddChoices(csprojs)
-                    );
+            await console!.Output.WriteLineAsync("No project matched the specified project filters.");
+            return;
+        }
 
-                    projectFiles = selectedProjects.ToArray();
-                }
-                else
-                {
-                    await console!.Output.WriteLineAsync("Interactive migration project selection is unavailable; running all matching '--migrate-database' projects.");
-                }
+        if (!RunAll && Projects.Length == 0 && projectFiles.Length > 1)
+        {
+            if (canUseInteractiveConsole)
+            {
+                var selectedProjects = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<FileInfo>()
+                        .Title("Select project(s) to run with '--migrate-database' parameter")
+                        .Required(true)
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more projects)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a project, [green]<enter>[/] to accept)[/]")
+                        .UseConverter(file => Path.GetRelativePath(WorkingDirectory!, file.FullName))
+                        .AddChoices(projectFiles)
+                );
+
+                projectFiles = selectedProjects.ToArray();
             }
             else
             {
-                projectFiles = projectFiles.Where(x => Projects.Any(y => x.FullName.Contains(y, StringComparison.InvariantCultureIgnoreCase))).ToArray();
+                await console!.Output.WriteLineAsync("Interactive migration project selection is unavailable; running all matching '--migrate-database' projects.");
             }
         }
 

--- a/src/AbpDevTools/Commands/RunCommand.cs
+++ b/src/AbpDevTools/Commands/RunCommand.cs
@@ -109,7 +109,8 @@ public partial class RunCommand : ICommand
 
         var cancellationToken = console.RegisterCancellationHandler();
 
-        if (TryLoadRootConfiguration(out var localRootConfig, out var loadedYmlPath))
+        var rootConfigurationLoaded = TryLoadRootConfiguration(out var localRootConfig, out var loadedYmlPath);
+        if (rootConfigurationLoaded)
         {
             console.Output.WriteLine($"Loaded YAML configuration from '{loadedYmlPath}' with environment '{localRootConfig?.Environment?.Name ?? "Default"}'.");
         }
@@ -145,7 +146,7 @@ public partial class RunCommand : ICommand
             migrateCommand.RunAll = this.RunAll;
             migrateCommand.Projects = this.Projects;
 
-            await migrateCommand.ExecuteAsync(console);
+            await migrateCommand.ExecuteAsync(console, localRootConfig, rootConfigurationLoaded);
         }
 
         await console.Output.WriteLineAsync("Starting projects...");

--- a/tests/AbpDevTools.Tests/Commands/MigrateCommandTests.cs
+++ b/tests/AbpDevTools.Tests/Commands/MigrateCommandTests.cs
@@ -4,11 +4,14 @@ using AbpDevTools.Environments;
 using AbpDevTools.LocalConfigurations;
 using AbpDevTools.Notifications;
 using AbpDevTools.Services;
+using CliFx.Infrastructure;
 using FluentAssertions;
 using NSubstitute;
+using System.Reflection;
+using System.Text;
 using Xunit;
 using YamlDotNet.Serialization;
-using System.Reflection;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace AbpDevTools.Tests.Commands;
 
@@ -41,9 +44,16 @@ public class MigrateCommandTests : IDisposable
         _toolsConfiguration = new ToolsConfiguration(mockDeserializer, mockSerializer);
 
         // Use real LocalConfigurationManager with mocked environment manager
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(HyphenatedNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+        var serializer = new SerializerBuilder()
+            .WithNamingConvention(HyphenatedNamingConvention.Instance)
+            .Build();
         _localConfigurationManager = new LocalConfigurationManager(
-            mockDeserializer,
-            mockSerializer,
+            deserializer,
+            serializer,
             new FileExplorer(),
             _mockEnvironmentManager);
 
@@ -250,6 +260,95 @@ public class MigrateCommandTests : IDisposable
         command.Should().NotBeNull();
     }
 
+    [Fact]
+    public void LoadLocalConfiguration_WithAbpdevYml_ReportsLoadedConfigurationAndAppliesProjects()
+    {
+        // Arrange
+        var configurationPath = Path.Combine(_testRootPath, "abpdev.yml");
+        File.WriteAllText(configurationPath, """
+            environment:
+              name: Development
+            run:
+              projects:
+                - Order
+            """);
+
+        var workingDirectory = Path.Combine(_testRootPath, "src");
+        Directory.CreateDirectory(workingDirectory);
+        CreateDbMigratorProject(workingDirectory, "Acme.Order.DbMigrator");
+        CreateDbMigratorProject(workingDirectory, "Acme.Identity.DbMigrator");
+
+        var command = CreateCommand();
+        command.WorkingDirectory = workingDirectory;
+        var console = new TestConsole();
+
+        // Act
+        command.InvokeLoadLocalConfiguration(console);
+
+        // Assert
+        command.Projects.Should().Equal("Order");
+        console.GetOutput().Should().Contain(
+            $"Loaded YAML configuration from '{Path.GetFullPath(configurationPath)}' with environment 'Development'.");
+
+        var filteredProjects = command.InvokeFindDbMigrators(out var discoveredCount);
+        discoveredCount.Should().Be(2);
+        filteredProjects.Select(project => project.Name).Should().Equal("Acme.Order.DbMigrator.csproj");
+    }
+
+    [Fact]
+    public void LoadLocalConfiguration_WithCommandLineProjects_PreservesCommandLineProjects()
+    {
+        // Arrange
+        File.WriteAllText(Path.Combine(_testRootPath, "abpdev.yml"), """
+            run:
+              projects:
+                - YamlProject
+            """);
+
+        var command = CreateCommand();
+        command.WorkingDirectory = _testRootPath;
+        command.Projects = new[] { "CommandLineProject" };
+
+        // Act
+        command.InvokeLoadLocalConfiguration(new TestConsole());
+
+        // Assert
+        command.Projects.Should().Equal("CommandLineProject");
+    }
+
+    [Fact]
+    public void LoadLocalConfiguration_WithPreloadedConfiguration_UsesItWithoutReloadingOrLogging()
+    {
+        // Arrange
+        File.WriteAllText(Path.Combine(_testRootPath, "abpdev.yml"), """
+            run:
+              projects:
+                - NearestYamlProject
+            """);
+
+        var preloadedConfiguration = new LocalConfiguration
+        {
+            Run = new LocalConfiguration.LocalRunOption
+            {
+                Projects = new[] { "ExplicitYamlProject" }
+            }
+        };
+
+        var command = CreateCommand();
+        command.WorkingDirectory = _testRootPath;
+        var console = new TestConsole();
+
+        // Act
+        command.InvokeLoadLocalConfiguration(
+            console,
+            preloadedConfiguration,
+            rootConfigurationLoaded: true);
+
+        // Assert
+        command.Projects.Should().Equal("ExplicitYamlProject");
+        console.GetOutput().Should().BeEmpty();
+    }
+
     #endregion
 
     #region Helper Methods
@@ -257,9 +356,9 @@ public class MigrateCommandTests : IDisposable
     /// <summary>
     /// Creates a MigrateCommand with mocked dependencies.
     /// </summary>
-    private MigrateCommand CreateCommand()
+    private TestMigrateCommand CreateCommand()
     {
-        return new MigrateCommand(
+        return new TestMigrateCommand(
             _mockNotificationManager,
             _mockEnvironmentManager,
             _toolsConfiguration,
@@ -277,6 +376,20 @@ public class MigrateCommandTests : IDisposable
         return projectDir;
     }
 
+    private static void CreateDbMigratorProject(string parentDirectory, string projectName)
+    {
+        var projectDirectory = Path.Combine(parentDirectory, projectName);
+        Directory.CreateDirectory(projectDirectory);
+        File.WriteAllText(Path.Combine(projectDirectory, $"{projectName}.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+    }
+
     /// <summary>
     /// Invokes the private IsDbMigrator method using reflection.
     /// </summary>
@@ -288,6 +401,85 @@ public class MigrateCommandTests : IDisposable
             throw new InvalidOperationException("IsDbMigrator method not found");
         }
         return (bool)method.Invoke(command, new object[] { projectPath })!;
+    }
+
+    [CliFx.Attributes.Command("test-migrate-command")]
+    private sealed class TestMigrateCommand : MigrateCommand
+    {
+        public TestMigrateCommand(
+            INotificationManager notificationManager,
+            IProcessEnvironmentManager environmentManager,
+            ToolsConfiguration toolsConfiguration,
+            LocalConfigurationManager localConfigurationManager,
+            RunnableProjectsProvider runnableProjectsProvider)
+            : base(
+                notificationManager,
+                environmentManager,
+                toolsConfiguration,
+                localConfigurationManager,
+                runnableProjectsProvider)
+        {
+        }
+
+        public void InvokeLoadLocalConfiguration(
+            IConsole console,
+            LocalConfiguration? localRootConfiguration = null,
+            bool rootConfigurationLoaded = false)
+        {
+            LoadLocalConfiguration(console, localRootConfiguration, rootConfigurationLoaded);
+        }
+
+        public FileInfo[] InvokeFindDbMigrators(out int discoveredCount)
+        {
+            return FindDbMigrators(out discoveredCount);
+        }
+    }
+
+    private sealed class TestConsole : IConsole
+    {
+        private readonly MemoryStream _inputStream = new();
+        private readonly MemoryStream _outputStream = new();
+        private readonly MemoryStream _errorStream = new();
+        private readonly Lazy<ConsoleReader> _input;
+        private readonly Lazy<ConsoleWriter> _output;
+        private readonly Lazy<ConsoleWriter> _error;
+
+        public TestConsole()
+        {
+            _input = new Lazy<ConsoleReader>(() => new ConsoleReader(this, _inputStream, Encoding.UTF8));
+            _output = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _outputStream, Encoding.UTF8));
+            _error = new Lazy<ConsoleWriter>(() => new ConsoleWriter(this, _errorStream, Encoding.UTF8));
+        }
+
+        public ConsoleReader Input => _input.Value;
+        public ConsoleWriter Output => _output.Value;
+        public ConsoleWriter Error => _error.Value;
+
+        public bool IsOutputRedirected => true;
+        public bool IsErrorRedirected => true;
+        public bool IsInputRedirected => true;
+
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+        public int WindowWidth { get; set; } = 120;
+        public int WindowHeight { get; set; } = 30;
+        public int CursorLeft { get; set; }
+        public int CursorTop { get; set; }
+
+        public CancellationToken RegisterCancellationHandler() => CancellationToken.None;
+        public ConsoleKeyInfo ReadKey(bool intercept = false) => default;
+        public void Clear() { }
+        public void ResetColor() { }
+
+        public string GetOutput()
+        {
+            if (_output.IsValueCreated)
+            {
+                _output.Value.Flush();
+            }
+
+            return Encoding.UTF8.GetString(_outputStream.ToArray());
+        }
     }
 
     #endregion


### PR DESCRIPTION
## What changed

- Load the nearest `abpdev.yml` when `abpdev migrate` starts and report the resolved path and environment, matching `abpdev run`.
- Use `run.projects` when no `--projects` option was supplied.
- Apply project filters to both direct `*.DbMigrator.csproj` projects and the `--migrate-database` fallback.
- Forward the configuration already resolved by `abpdev run`, including an explicit `--yml` file, so migration uses the same project filters without printing the loaded message twice.

## Why

`migrate` previously loaded local environment settings silently for each process, but it did not report the YAML file or consume its project selection. The existing `--projects` option also did not filter direct DbMigrator projects.

## Validation

- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj --filter FullyQualifiedName~MigrateCommandTests --no-restore --nologo` — 12 passed
- `dotnet test tests/AbpDevTools.Tests/AbpDevTools.Tests.csproj --no-restore --nologo` — 560 passed
- `dotnet build AbpDevTools.sln --no-restore --nologo` — succeeded
- `git diff --check` — passed

The build retains the repository's existing duplicate `FluentAssertions` and xUnit version-resolution warnings.
