### PR TITLE
feat: support standard environment variables for non-interactive CLI mode

### DIFF
--- a/src/AbpDevTools/Commands/AddPackageCommand.cs
+++ b/src/AbpDevTools/Commands/AddPackageCommand.cs
@@ -61,6 +61,12 @@ public class AddPackageCommand : ICommand
 
         if (projectFiles.Length > 1 && !AddToAll && string.IsNullOrEmpty(ProjectPath))
         {
+            if (!ConsoleSupport.SupportsInteractiveConsole(console))
+            {
+                await console.Output.WriteLineAsync("Interactive project selection is unavailable; specify a project with '--project' or pass '--all' to add the package to all projects.");
+                return;
+            }
+
             var chosenProjects = AnsiConsole.Prompt(new MultiSelectionPrompt<string>()
                 .Title("Choose projects to add the package.")
                 .Required(true)

--- a/src/AbpDevTools/Commands/BuildCommand.cs
+++ b/src/AbpDevTools/Commands/BuildCommand.cs
@@ -22,6 +22,7 @@ public class BuildCommand : ICommand
     [CommandOption("configuration", 'c')]
     public string? Configuration { get; set; }
 
+    protected IConsole? console;
     Process? runningProcess;
     protected readonly INotificationManager notificationManager;
     protected readonly ToolsConfiguration toolsConfiguration;
@@ -34,6 +35,7 @@ public class BuildCommand : ICommand
 
     public async ValueTask ExecuteAsync(IConsole console)
     {
+        this.console = console;
         if (string.IsNullOrEmpty(WorkingDirectory))
         {
             WorkingDirectory = Directory.GetCurrentDirectory();
@@ -208,7 +210,7 @@ public class BuildCommand : ICommand
                     return fileInfos;
                 });
 
-        if (Interactive && files.Length > 1)
+        if (Interactive && ConsoleSupport.SupportsInteractiveConsole(console) && files.Length > 1)
         {
             var fileChoices = files.Select(s => s.FullName.Replace(WorkingDirectory!, ".")).ToArray();
             

--- a/src/AbpDevTools/Commands/FindPortCommand.cs
+++ b/src/AbpDevTools/Commands/FindPortCommand.cs
@@ -43,6 +43,28 @@ public class FindPortCommand : ICommand
             return;
         }
 
+        if (!ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            var table = new Table()
+                .Border(TableBorder.Rounded)
+                .AddColumn("[grey]#[/]")
+                .AddColumn("[grey]PID[/]")
+                .AddColumn("[grey]Process Name[/]");
+
+            foreach (var (process, index) in processes.Select((p, i) => (p, i)))
+            {
+                table.AddRow(
+                    $"{index + 1}",
+                    $"[mediumpurple2]{process.Pid}[/]",
+                    $"[green]{process.ProcessName}[/]"
+                );
+            }
+
+            AnsiConsole.Write(table);
+            await console.Output.WriteLineAsync("Interactive menu is unavailable. Pass '--kill' ('-k') to terminate the found process directly.");
+            return;
+        }
+
         while (true)
         {
             AnsiConsole.Clear();

--- a/src/AbpDevTools/Commands/LogsClearCommand.cs
+++ b/src/AbpDevTools/Commands/LogsClearCommand.cs
@@ -1,4 +1,4 @@
-﻿using AbpDevTools.Configuration;
+using AbpDevTools.Configuration;
 using AbpDevTools.Services;
 using CliFx.Infrastructure;
 using Spectre.Console;
@@ -38,6 +38,11 @@ public class LogsClearCommand : ICommand
         }
 
         var csprojs = runnableProjectsProvider.GetRunnableProjects(WorkingDirectory);
+
+        if (Interactive && !ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            Interactive = false;
+        }
 
         if (string.IsNullOrEmpty(ProjectName))
         {

--- a/src/AbpDevTools/Commands/LogsCommand.cs
+++ b/src/AbpDevTools/Commands/LogsCommand.cs
@@ -42,6 +42,11 @@ public class LogsCommand : ICommand
 
         var csprojs = runnableProjectsProvider.GetRunnableProjects(WorkingDirectory);
 
+        if (Interactive && !ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            Interactive = false;
+        }
+
         if (string.IsNullOrEmpty(ProjectName))
         {
             if (Interactive)

--- a/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
+++ b/src/AbpDevTools/Commands/Migrations/MigrationsCommandBase.cs
@@ -1,4 +1,4 @@
-﻿using AbpDevTools.Services;
+using AbpDevTools.Services;
 using CliFx.Infrastructure;
 using Spectre.Console;
 
@@ -21,8 +21,11 @@ public abstract class MigrationsCommandBase : ICommand
         this.entityFrameworkCoreProjectsProvider = entityFrameworkCoreProjectsProvider;
     }
 
+    protected IConsole? console;
+
     public virtual ValueTask ExecuteAsync(IConsole console)
     {
+        this.console = console;
         if (string.IsNullOrEmpty(WorkingDirectory))
         {
             WorkingDirectory = Directory.GetCurrentDirectory();
@@ -58,6 +61,12 @@ public abstract class MigrationsCommandBase : ICommand
 
     protected virtual FileInfo[] PromptForProjectSelection(FileInfo[] projectFiles)
     {
+        if (console != null && !ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            console.Output.WriteLine("Interactive project selection is unavailable; running for all detected EF Core projects. Pass '--projects' to specify.");
+            return projectFiles;
+        }
+
         var chosenProjects = AnsiConsole.Prompt(new MultiSelectionPrompt<FileInfo>()
                 .Title("Choose project to create migrations.")
                 .Required(true)

--- a/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
+++ b/src/AbpDevTools/Commands/References/SwitchReferencesToLocalCommand.cs
@@ -255,6 +255,12 @@ public class SwitchReferencesToLocalCommand : ICommand
         
         AnsiConsole.MarkupLine($"[yellow]Source '{sourceKey}' is empty or doesn't exist at:[/] {sourceConfig.Path}");
         
+        if (!ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            console.Output.WriteLine($"Interactive prompt unavailable; skipping missing source '{sourceKey}'.");
+            return SourceAction.Skip;
+        }
+
         var choices = new List<string>
         {
             "Skip this source",

--- a/src/AbpDevTools/Commands/References/SwitchReferencesToPackageCommand.cs
+++ b/src/AbpDevTools/Commands/References/SwitchReferencesToPackageCommand.cs
@@ -228,7 +228,7 @@ public class SwitchReferencesToPackageCommand : ICommand
                 if (!DoesProjectMatchAnyPattern(projectName, sourceConfig.Packages)) continue;
 
                 // Get version (from backup or prompt user)
-                var version = GetVersionForSource(doc, sourceKey, promptedVersions);
+                var version = GetVersionForSource(doc, sourceKey, promptedVersions, console);
                 if (string.IsNullOrEmpty(version)) continue;
 
                 // Convert to PackageReference
@@ -308,7 +308,7 @@ public class SwitchReferencesToPackageCommand : ICommand
         return false;
     }
 
-    private string? GetVersionForSource(XDocument doc, string sourceKey, Dictionary<string, string> promptedVersions)
+    private string? GetVersionForSource(XDocument doc, string sourceKey, Dictionary<string, string> promptedVersions, IConsole console)
     {
         // First, try to get from backed-up version
         var backedUpVersion = csprojService.GetBackedUpVersion(doc, sourceKey);
@@ -321,6 +321,12 @@ public class SwitchReferencesToPackageCommand : ICommand
         if (promptedVersions.TryGetValue(sourceKey, out var cachedVersion))
         {
             return cachedVersion;
+        }
+
+        if (!ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            console.Output.WriteLine($"Interactive prompt unavailable; cannot determine version for source '{sourceKey}'. Skipping.");
+            return null;
         }
 
         // Prompt user for version
@@ -341,6 +347,12 @@ public class SwitchReferencesToPackageCommand : ICommand
         
         AnsiConsole.MarkupLine($"[yellow]Source '{sourceKey}' is empty or doesn't exist at:[/] {sourceConfig.Path}");
         
+        if (!ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            console.Output.WriteLine($"Interactive prompt unavailable; skipping missing source '{sourceKey}'.");
+            return SourceAction.Skip;
+        }
+
         var choices = new List<string>
         {
             "Skip this source",

--- a/src/AbpDevTools/Commands/ReplaceCommand.cs
+++ b/src/AbpDevTools/Commands/ReplaceCommand.cs
@@ -1,4 +1,4 @@
-﻿using AbpDevTools.Configuration;
+using AbpDevTools.Configuration;
 using CliFx.Infrastructure;
 using Spectre.Console;
 using System.Text;
@@ -31,6 +31,11 @@ public class ReplaceCommand : ICommand
     public async ValueTask ExecuteAsync(IConsole console)
     {
         WorkingDirectory ??= Directory.GetCurrentDirectory();
+
+        if (InteractiveMode && !ConsoleSupport.SupportsInteractiveConsole(console))
+        {
+            InteractiveMode = false;
+        }
 
         var options = replacementConfiguration.GetOptions();
         List<string>? filesToProcess = null;

--- a/src/AbpDevTools/Commands/TestCommand.cs
+++ b/src/AbpDevTools/Commands/TestCommand.cs
@@ -1,4 +1,4 @@
-﻿using AbpDevTools.Configuration;
+using AbpDevTools.Configuration;
 using CliFx.Infrastructure;
 using Spectre.Console;
 using System.Diagnostics;
@@ -126,7 +126,7 @@ public class TestCommand : ICommand
                     return fileInfo;
                 });
 
-        if (Interactive && files.Length > 1)
+        if (Interactive && ConsoleSupport.SupportsInteractiveConsole(console) && files.Length > 1)
         {
             var choosed = AnsiConsole.Prompt(
                 new MultiSelectionPrompt<string>()

--- a/src/AbpDevTools/ConsoleSupport.cs
+++ b/src/AbpDevTools/ConsoleSupport.cs
@@ -66,62 +66,33 @@ internal static class ConsoleSupport
         }
     }
 
+    private static readonly (string Variable, Func<string, bool> IsMatch)[] NonInteractiveRules =
+    [
+        ("ABPDEV_NON_INTERACTIVE", IsTrueOrOne),
+        ("ABPDEV_INTERACTIVE", IsFalseOrZero),
+        ("NONINTERACTIVE", IsTrueOrOne),
+        ("NON_INTERACTIVE", IsTrueOrOne),
+        ("CI", IsTrueOrOne),
+        ("DEBIAN_FRONTEND", v => v.Equals("noninteractive", StringComparison.OrdinalIgnoreCase)),
+        ("TERM", v => v.Equals("dumb", StringComparison.OrdinalIgnoreCase)),
+    ];
+
     public static bool IsNonInteractiveEnvironment(Func<string, string?>? getEnvironmentVariable = null)
     {
         getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
 
-        var abpDevNonInteractive = getEnvironmentVariable("ABPDEV_NON_INTERACTIVE");
-        if (IsTrueOrOne(abpDevNonInteractive))
+        return NonInteractiveRules.Any(rule =>
         {
-            return true;
-        }
-
-        var abpDevInteractive = getEnvironmentVariable("ABPDEV_INTERACTIVE");
-        if (IsFalseOrZero(abpDevInteractive))
-        {
-            return true;
-        }
-
-        var nonInteractive = getEnvironmentVariable("NONINTERACTIVE");
-        if (IsTrueOrOne(nonInteractive))
-        {
-            return true;
-        }
-
-        var nonInteractiveUnderscore = getEnvironmentVariable("NON_INTERACTIVE");
-        if (IsTrueOrOne(nonInteractiveUnderscore))
-        {
-            return true;
-        }
-
-        var ci = getEnvironmentVariable("CI");
-        if (IsTrueOrOne(ci))
-        {
-            return true;
-        }
-
-        var debianFrontend = getEnvironmentVariable("DEBIAN_FRONTEND");
-        if (string.Equals(debianFrontend?.Trim(), "noninteractive", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        var term = getEnvironmentVariable("TERM");
-        if (string.Equals(term?.Trim(), "dumb", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return false;
+            var value = getEnvironmentVariable(rule.Variable)?.Trim();
+            return !string.IsNullOrEmpty(value) && rule.IsMatch(value);
+        });
     }
 
-    private static bool IsTrueOrOne(string? value) =>
-        string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value?.Trim(), "1", StringComparison.OrdinalIgnoreCase);
+    private static bool IsTrueOrOne(string value) =>
+        value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1";
 
-    private static bool IsFalseOrZero(string? value) =>
-        string.Equals(value?.Trim(), "false", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value?.Trim(), "0", StringComparison.OrdinalIgnoreCase);
+    private static bool IsFalseOrZero(string value) =>
+        value.Equals("false", StringComparison.OrdinalIgnoreCase) || value == "0";
 
     public static bool TryGetWindowWidth(IConsole? console, out int windowWidth)
     {

--- a/src/AbpDevTools/ConsoleSupport.cs
+++ b/src/AbpDevTools/ConsoleSupport.cs
@@ -15,8 +15,15 @@ internal static class ConsoleSupport
             (text, value) => AnsiConsole.Prompt(new ConfirmationPrompt(text) { DefaultValue = value }));
     }
 
-    public static bool CanReadConsoleInput()
+    public static bool CanReadConsoleInput() => CanReadConsoleInput(null);
+
+    public static bool CanReadConsoleInput(Func<string, string?>? getEnvironmentVariable)
     {
+        if (IsNonInteractiveEnvironment(getEnvironmentVariable))
+        {
+            return false;
+        }
+
         try
         {
             return !Console.IsInputRedirected;
@@ -31,9 +38,16 @@ internal static class ConsoleSupport
         }
     }
 
-    public static bool SupportsInteractiveConsole(IConsole? console)
+    public static bool SupportsInteractiveConsole(IConsole? console) => SupportsInteractiveConsole(console, null);
+
+    public static bool SupportsInteractiveConsole(IConsole? console, Func<string, string?>? getEnvironmentVariable)
     {
         if (console is null)
+        {
+            return false;
+        }
+
+        if (IsNonInteractiveEnvironment(getEnvironmentVariable))
         {
             return false;
         }
@@ -51,6 +65,63 @@ internal static class ConsoleSupport
             return false;
         }
     }
+
+    public static bool IsNonInteractiveEnvironment(Func<string, string?>? getEnvironmentVariable = null)
+    {
+        getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
+
+        var abpDevNonInteractive = getEnvironmentVariable("ABPDEV_NON_INTERACTIVE");
+        if (IsTrueOrOne(abpDevNonInteractive))
+        {
+            return true;
+        }
+
+        var abpDevInteractive = getEnvironmentVariable("ABPDEV_INTERACTIVE");
+        if (IsFalseOrZero(abpDevInteractive))
+        {
+            return true;
+        }
+
+        var nonInteractive = getEnvironmentVariable("NONINTERACTIVE");
+        if (IsTrueOrOne(nonInteractive))
+        {
+            return true;
+        }
+
+        var nonInteractiveUnderscore = getEnvironmentVariable("NON_INTERACTIVE");
+        if (IsTrueOrOne(nonInteractiveUnderscore))
+        {
+            return true;
+        }
+
+        var ci = getEnvironmentVariable("CI");
+        if (IsTrueOrOne(ci))
+        {
+            return true;
+        }
+
+        var debianFrontend = getEnvironmentVariable("DEBIAN_FRONTEND");
+        if (string.Equals(debianFrontend?.Trim(), "noninteractive", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var term = getEnvironmentVariable("TERM");
+        if (string.Equals(term?.Trim(), "dumb", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsTrueOrOne(string? value) =>
+        string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value?.Trim(), "1", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsFalseOrZero(string? value) =>
+        string.Equals(value?.Trim(), "false", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value?.Trim(), "0", StringComparison.OrdinalIgnoreCase);
 
     public static bool TryGetWindowWidth(IConsole? console, out int windowWidth)
     {

--- a/src/AbpDevTools/ConsoleSupport.cs
+++ b/src/AbpDevTools/ConsoleSupport.cs
@@ -81,6 +81,18 @@ internal static class ConsoleSupport
     {
         getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
 
+        var abpDevInteractive = getEnvironmentVariable("ABPDEV_INTERACTIVE")?.Trim();
+        if (IsTrueOrOne(abpDevInteractive))
+        {
+            return false;
+        }
+
+        var abpDevNonInteractive = getEnvironmentVariable("ABPDEV_NON_INTERACTIVE")?.Trim();
+        if (IsFalseOrZero(abpDevNonInteractive))
+        {
+            return false;
+        }
+
         return NonInteractiveRules.Any(rule =>
         {
             var value = getEnvironmentVariable(rule.Variable)?.Trim();
@@ -88,11 +100,11 @@ internal static class ConsoleSupport
         });
     }
 
-    private static bool IsTrueOrOne(string value) =>
-        value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1";
+    private static bool IsTrueOrOne(string? value) =>
+        !string.IsNullOrEmpty(value) && (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1");
 
-    private static bool IsFalseOrZero(string value) =>
-        value.Equals("false", StringComparison.OrdinalIgnoreCase) || value == "0";
+    private static bool IsFalseOrZero(string? value) =>
+        !string.IsNullOrEmpty(value) && (value.Equals("false", StringComparison.OrdinalIgnoreCase) || value == "0");
 
     public static bool TryGetWindowWidth(IConsole? console, out int windowWidth)
     {

--- a/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
+++ b/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
@@ -53,6 +53,66 @@ public class ConsoleSupportTests
         console.GetOutput().Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "true", true)]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "1", true)]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "True", true)]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "false", false)]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "0", false)]
+    [InlineData("ABPDEV_INTERACTIVE", "false", true)]
+    [InlineData("ABPDEV_INTERACTIVE", "0", true)]
+    [InlineData("ABPDEV_INTERACTIVE", "False", true)]
+    [InlineData("ABPDEV_INTERACTIVE", "true", false)]
+    [InlineData("ABPDEV_INTERACTIVE", "1", false)]
+    [InlineData("NONINTERACTIVE", "true", true)]
+    [InlineData("NONINTERACTIVE", "1", true)]
+    [InlineData("NON_INTERACTIVE", "true", true)]
+    [InlineData("NON_INTERACTIVE", "1", true)]
+    [InlineData("CI", "true", true)]
+    [InlineData("CI", "1", true)]
+    [InlineData("CI", "false", false)]
+    [InlineData("CI", "0", false)]
+    [InlineData("DEBIAN_FRONTEND", "noninteractive", true)]
+    [InlineData("DEBIAN_FRONTEND", "dialog", false)]
+    [InlineData("TERM", "dumb", true)]
+    [InlineData("TERM", "DUMB", true)]
+    [InlineData("TERM", "xterm-256color", false)]
+    [InlineData("OTHER_VAR", "value", false)]
+    public void IsNonInteractiveEnvironment_ReturnsExpectedResult(string key, string value, bool expected)
+    {
+        // Act
+        var result = ConsoleSupport.IsNonInteractiveEnvironment(varName =>
+            string.Equals(varName, key, StringComparison.OrdinalIgnoreCase) ? value : null);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SupportsInteractiveConsole_WhenNonInteractiveEnvVarSet_ReturnsFalseEvenIfStreamsUnredirected()
+    {
+        // Arrange
+        var console = new TestConsole(isInputRedirected: false, isOutputRedirected: false, isErrorRedirected: false);
+
+        // Act
+        var result = ConsoleSupport.SupportsInteractiveConsole(
+            console,
+            varName => varName == "CI" ? "true" : null);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanReadConsoleInput_WhenNonInteractiveEnvVarSet_ReturnsFalse()
+    {
+        // Act
+        var result = ConsoleSupport.CanReadConsoleInput(varName => varName == "NONINTERACTIVE" ? "1" : null);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
     private sealed class TestConsole : IConsole
     {
         private readonly MemoryStream _inputStream = new();

--- a/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
+++ b/tests/AbpDevTools.Tests/ConsoleSupportTests.cs
@@ -88,6 +88,26 @@ public class ConsoleSupportTests
         result.Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData("ABPDEV_INTERACTIVE", "true")]
+    [InlineData("ABPDEV_INTERACTIVE", "1")]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "false")]
+    [InlineData("ABPDEV_NON_INTERACTIVE", "0")]
+    public void IsNonInteractiveEnvironment_WhenExplicitInteractiveOverrideSet_OverridesCIEnvironment(string overrideKey, string overrideValue)
+    {
+        // Act: CI is set to true, but explicit interactive override is provided
+        var result = ConsoleSupport.IsNonInteractiveEnvironment(varName =>
+        {
+            if (string.Equals(varName, overrideKey, StringComparison.OrdinalIgnoreCase)) return overrideValue;
+            if (string.Equals(varName, "CI", StringComparison.OrdinalIgnoreCase)) return "true";
+            if (string.Equals(varName, "TERM", StringComparison.OrdinalIgnoreCase)) return "dumb";
+            return null;
+        });
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
     [Fact]
     public void SupportsInteractiveConsole_WhenNonInteractiveEnvVarSet_ReturnsFalseEvenIfStreamsUnredirected()
     {


### PR DESCRIPTION
## Summary
Integrates industry-standard and CLI-specific environment variables to automatically suppress interactive prompts and rich live console rendering across all bpdev commands when running in CI/CD, automation scripts, or AI agent tool invocations.

## Supported Environment Variables

| Variable | Values (case-insensitive) | Description |
| :--- | :--- | :--- |
| ABPDEV_NON_INTERACTIVE | 	rue, 1 | AbpDevTools-specific non-interactive flag |
| ABPDEV_INTERACTIVE | alse, 